### PR TITLE
fix info script so timing script doesn't fail if undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testing.js
 other.js
 .DS_Store
+long-tasks.js

--- a/README.md
+++ b/README.md
@@ -221,10 +221,20 @@ function getScriptInfo() {
     }
   });
 
-  return {
-    ...(first.length && { firstParty: first }),
-    ...(third.length && { thirdParty: third }),
+  const scripts = {
+    firstParty: [{ name: "no data" }],
+    thirdParty: [{ name: "no data" }],
   };
+
+  if (first.length) {
+    scripts.firstParty = first;
+  }
+
+  if (third.length) {
+    scripts.thirdParty = third;
+  }
+
+  return scripts;
 }
 
 const { firstParty, thirdParty } = getScriptInfo();
@@ -279,14 +289,17 @@ function createUniqueLists(firstParty, thirdParty) {
 
   const firstPartyList = getUniqueListBy(firstParty, ["name"]);
   const thirdPartyList = getUniqueListBy(thirdParty, ["name"]);
-
+  
   return { firstPartyList, thirdPartyList };
+
 }
 
 const { firstPartyList, thirdPartyList } = createUniqueLists(
   firstParty,
   thirdParty
 );
+
+
 
 function calculateTimings(party, type) {
   const partyChoice = party === "first" ? firstParty : thirdParty;


### PR DESCRIPTION
changed this code to avoid empty arrays without objects with 'name' property

```
const scripts = {
    firstParty: [{ name: "no data" }],
    thirdParty: [{ name: "no data" }],
  };

  if (first.length) {
    scripts.firstParty = first;
  }

  if (third.length) {
    scripts.thirdParty = third;
  }

return scripts
```
 
Tested by running on apple.com which has no third party scripts. Note timing script does not fail.

![pic-Google Chrome-Apple-07-152022 2](https://user-images.githubusercontent.com/42519030/179336430-419e06d3-933f-48ed-8a44-f22674fd0c35.jpg)
