### PR TITLE
Track lazyloaded images with JS above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,17 +168,15 @@ List all images that have `loading="lazy"` above the fold
 
 ```js
 function findATFLazyLoadedImages() {
-  const lazy = document.querySelectorAll('[loading="lazy"]');
-  let flag = false;
+  const lazy = document.querySelectorAll('[loading="lazy"], [data-src]');
+  let lazyImages = [];
   lazy.forEach((tag) => {
     const position = parseInt(tag.getBoundingClientRect().top);
     if (position < window.innerHeight && position !== 0) {
-      console.log(tag, position);
-      flag = true;
+      lazyImages = [...lazyImages, tag];
     }
   });
-
-  return flag;
+  return lazyImages.length > 0 ? lazyImages : false;
 }
 
 console.log(findATFLazyLoadedImages());


### PR DESCRIPTION
# Description

According to the 2022 Web Almanac, 9.8% of mobile pages with image-based LCP set loading=lazy on them. And 8,8% use custom lazy-loading. 

The current snippet only tracks lazy-loaded images using the native `loading="lazy"` attribute. Hence, it's only useful for 52% of mobile pages using any lazy-loading approach on LCP images.

# Proposed solution

With this update, the snippet also tracks lazy-loaded images via JS, looking for "data-src" attributes.

I've also updated the return statement to return an array with all the lazy-loaded elements or `false` if no image above the fold was lazy-loaded.