### PR TITLE
Some doc.images missing `performance.*` entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ console.table(
     )
     .map((img) => [
       img.currentSrc,
-      (performance.getEntriesByName(img.currentSrc)[0].encodedBodySize * 8) /
+      (performance.getEntriesByName(img.currentSrc)[0]?.encodedBodySize * 8) /
         (img.width * img.height),
     ])
     .filter((img) => img[1] !== 0)


### PR DESCRIPTION
So `?` for optional.