### PR TITLE
feat: add webperf-snippets CLI (MVP)

### DIFF
--- a/.claude/skills/webperf-core-web-vitals/references/schema.md
+++ b/.claude/skills/webperf-core-web-vitals/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/.claude/skills/webperf-interaction/references/schema.md
+++ b/.claude/skills/webperf-interaction/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/.claude/skills/webperf-loading/references/schema.md
+++ b/.claude/skills/webperf-loading/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/.claude/skills/webperf-media/references/schema.md
+++ b/.claude/skills/webperf-media/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/.claude/skills/webperf-resources/references/schema.md
+++ b/.claude/skills/webperf-resources/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Check consistency
         run: npm run check:consistency
 
-      - name: Install CLI dependencies
-        run: npm ci --prefix cli
-
       - name: Run unit tests
         run: npm run test:unit --prefix cli
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,16 @@ jobs:
 
       - name: Check consistency
         run: npm run check:consistency
+
+      - name: Install CLI dependencies
+        run: npm ci --prefix cli
+
+      - name: Run unit tests
+        run: npm run test:unit --prefix cli
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: cli
+
+      - name: Run E2E tests
+        run: npm run test:e2e --prefix cli

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
     permissions:
       contents: read
 

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e --prefix cli
 
+      - name: Prepare snippets for publishing
+        run: cp -r snippets cli/
+
       - name: Publish to npm
         run: npm publish
         working-directory: cli

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,42 @@
+name: Publish CLI
+
+on:
+  push:
+    tags:
+      - 'cli-v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm run test:unit --prefix cli
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: cli
+
+      - name: Run E2E tests
+        run: npm run test:e2e --prefix cli
+
+      - name: Publish to npm
+        run: npm publish
+        working-directory: cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Skills are compatible with [Chrome DevTools MCP](https://github.com/modelcontext
 
 **Supported agents**: Claude Code, Cursor, OpenCode, Gemini CLI, VS Code extensions, and [many more](https://agentskills.io/).
 
+## CLI
+
+The repository includes a headless CLI (`cli/`) that runs WebPerf Snippets via Playwright — useful for CI pipelines and performance budgeting without copy-pasting into DevTools.
+
+```bash
+npx webperf-snippets https://example.com --budget-lcp 2500 --budget-cls 0.1
+```
+
+See [`cli/README.md`](./cli/README.md) for installation, usage, and CI integration. The CLI is published to npm as [`webperf-snippets`](https://www.npmjs.com/package/webperf-snippets) via a tag-based release workflow — pushing a `cli-v*` tag triggers the publish pipeline.
+
 ## Documentation
 
 Visit **[webperf-snippets.nucliweb.net](https://webperf-snippets.nucliweb.net)** for the full documentation with all snippets.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Skills are compatible with [Chrome DevTools MCP](https://github.com/modelcontext
 The repository includes a headless CLI (`cli/`) that runs WebPerf Snippets via Playwright — useful for CI pipelines and performance budgeting without copy-pasting into DevTools.
 
 ```bash
-npx webperf-snippets https://example.com --budget-lcp 2500 --budget-cls 0.1
+npx webperf-snippets https://web.dev --budget-lcp 2500 --budget-cls 0.1
 ```
 
 See [`cli/README.md`](./cli/README.md) for installation, usage, and CI integration. The CLI is published to npm as [`webperf-snippets`](https://www.npmjs.com/package/webperf-snippets) via a tag-based release workflow — pushing a `cli-v*` tag triggers the publish pipeline.

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,13 +44,13 @@ npx webperf-snippets https://web.dev --json
 Single snippet:
 
 ```bash
-npx webperf-snippets https://example.com --snippet LCP-Subparts
+npx webperf-snippets https://web.dev --snippet LCP-Subparts
 ```
 
 CI gating:
 
 ```bash
-npx webperf-snippets https://example.com --budget-lcp 2500 --budget-cls 0.1
+npx webperf-snippets https://web.dev --budget-lcp 2500 --budget-cls 0.1
 ```
 
 ### Options
@@ -82,7 +82,7 @@ GitHub Actions, fail the PR if LCP exceeds 2.5s:
 - run: |
     npm install --no-save webperf-snippets playwright
     npx playwright install --with-deps chromium
-    npx webperf-snippets https://staging.example.com --budget-lcp 2500 --budget-cls 0.1
+    npx webperf-snippets https://staging.web.dev --budget-lcp 2500 --budget-cls 0.1
 ```
 
 ## Publishing

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,7 +29,7 @@ npx webperf-snippets <url> [options]
 
 ### Examples
 
-Run the default Core Web Vitals workflow (LCP + CLS, plus LCP-Sub-Parts if LCP > 2.5s):
+Run the default Core Web Vitals workflow (LCP + CLS, plus LCP-Subparts if LCP > 2.5s):
 
 ```bash
 npx webperf-snippets https://web.dev
@@ -44,7 +44,7 @@ npx webperf-snippets https://web.dev --json
 Single snippet:
 
 ```bash
-npx webperf-snippets https://example.com --snippet LCP-Sub-Parts
+npx webperf-snippets https://example.com --snippet LCP-Subparts
 ```
 
 CI gating:
@@ -117,7 +117,7 @@ The `NPM_TOKEN` secret must be set in the repository settings with publish acces
 - **No INP**: INP requires real user interactions. v0.2 will support synthetic interaction scripts.
 - **CLS in headless is conservative**: layout shifts that only happen on scroll are missed unless you script the scroll.
 - **First navigation only**: each `webperf-snippets` invocation runs one URL. SPAs need the post-route URL passed directly.
-- **Decision-tree follow-ups re-navigate**: when a follow-up snippet fires (e.g. LCP-Sub-Parts), the page is loaded again. v0.2 will share a single page session.
+- **Decision-tree follow-ups re-navigate**: when a follow-up snippet fires (e.g. LCP-Subparts), the page is loaded again. v0.2 will share a single page session.
 
 ## Roadmap
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,112 @@
+# webperf-snippets CLI
+
+Run curated [WebPerf Snippets](https://webperf-snippets.nucliweb.net) headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes and gate CI on real performance budgets.
+
+> **Status:** v0.1 (MVP). Core Web Vitals workflow only. See [Roadmap](#roadmap) for what's next.
+
+## Why
+
+Lighthouse gives you a score. The DevTools snippets give you the *diagnosis* — TTFB / Resource Load Delay / Element Render Delay sub-parts, LoAF script attribution, render-blocking resources, etc. This CLI runs the same curated snippets in a headless browser so you can:
+
+- Diagnose LCP regressions in CI without copy-pasting into DevTools.
+- Gate pull requests on real performance budgets.
+- Automate the snippets you already run by hand.
+
+## Install
+
+Playwright is a peer dependency. Install both, plus the chromium browser:
+
+```bash
+npm install --save-dev webperf-snippets playwright
+npx playwright install chromium
+```
+
+## Usage
+
+```bash
+npx webperf-snippets <url> [options]
+```
+
+### Examples
+
+Run the default Core Web Vitals workflow (LCP + CLS, plus LCP-Sub-Parts if LCP > 2.5s):
+
+```bash
+npx webperf-snippets https://web.dev
+```
+
+JSON output (for piping into `jq` or CI):
+
+```bash
+npx webperf-snippets https://web.dev --json
+```
+
+Single snippet:
+
+```bash
+npx webperf-snippets https://example.com --snippet LCP-Sub-Parts
+```
+
+CI gating:
+
+```bash
+npx webperf-snippets https://example.com --budget-lcp 2500 --budget-cls 0.1
+```
+
+### Options
+
+| Option                | Description                                                |
+| --------------------- | ---------------------------------------------------------- |
+| `--workflow <name>`   | Workflow to run. Default: `core-web-vitals`.               |
+| `--snippet <name>`    | Run a single snippet (`LCP`, `CLS`, or `Category/Name`).   |
+| `--json`              | Output JSON instead of formatted text.                     |
+| `--wait <ms>`         | Post-load wait before evaluating snippets. Default: `3000`.|
+| `--budget-lcp <ms>`   | Exit `1` if LCP exceeds this value.                        |
+| `--budget-cls <score>`| Exit `1` if CLS exceeds this value.                        |
+| `--headed`            | Show the browser window (debug).                           |
+| `-h, --help`          | Show help.                                                 |
+
+### Exit codes
+
+| Code | Meaning                                       |
+| ---- | --------------------------------------------- |
+| `0`  | All checks passed.                            |
+| `1`  | Budget violation, or a snippet errored.       |
+| `2`  | Usage error (missing URL, unknown workflow).  |
+
+## CI example
+
+GitHub Actions, fail the PR if LCP exceeds 2.5s:
+
+```yaml
+- run: |
+    npm install --no-save webperf-snippets playwright
+    npx playwright install --with-deps chromium
+    npx webperf-snippets https://staging.example.com --budget-lcp 2500 --budget-cls 0.1
+```
+
+## Known limitations (v0.1)
+
+- **No INP**: INP requires real user interactions. v0.2 will support synthetic interaction scripts.
+- **CLS in headless is conservative**: layout shifts that only happen on scroll are missed unless you script the scroll.
+- **First navigation only**: each `webperf-snippets` invocation runs one URL. SPAs need the post-route URL passed directly.
+- **Decision-tree follow-ups re-navigate**: when a follow-up snippet fires (e.g. LCP-Sub-Parts), the page is loaded again. v0.2 will share a single page session.
+
+## Roadmap
+
+- v0.2: Loading workflow (TTFB, FCP, render-blocking, scripts, fonts), shared page session, synthetic interactions for INP.
+- v0.3: Markdown reporter for PR comments, GitHub Action wrapper.
+- v0.4: Auth flows (login + measure logged-in pages), CrUX field-data enrichment.
+
+## How it works
+
+1. Launches headless chromium via Playwright.
+2. Pre-registers `PerformanceObserver`s for LCP and layout-shift before navigation (Chrome doesn't expose these via `getEntriesByType` without a buffered observer, so the runner shims it).
+3. Navigates, waits for the page to settle.
+4. Evaluates each snippet's IIFE in the page context, capturing the returned object.
+5. Applies the workflow's decision tree to enqueue follow-up snippets.
+6. Renders results (human or JSON) and exits with an appropriate code.
+
+## License
+
+MIT — see [LICENSE](../LICENSE).

--- a/cli/README.md
+++ b/cli/README.md
@@ -85,6 +85,33 @@ GitHub Actions, fail the PR if LCP exceeds 2.5s:
     npx webperf-snippets https://staging.example.com --budget-lcp 2500 --budget-cls 0.1
 ```
 
+## Publishing
+
+The CLI package is published to npm via a tag-based workflow. Publishing is explicit and intentional — it only happens when a `cli-v*` tag is pushed.
+
+### Release steps
+
+1. Bump the version in `cli/package.json`.
+2. Commit the version change.
+3. Tag and push:
+   ```bash
+   git tag cli-v0.2.0
+   git push origin cli-v0.2.0
+   ```
+4. The `publish-cli` CI job runs, executes the full test suite, and publishes to npm.
+
+### Why tag-based and not path-based
+
+An alternative is to publish automatically on every push to `main` that touches `cli/`, using a version check to skip republishes. Tag-based publishing was chosen instead because it keeps releases deliberate — a passing CI on `main` does not mean the package is ready to ship, and a tag communicates that intent explicitly.
+
+### Access control
+
+Tag protection rules restrict who can push `cli-v*` tags. Configure them under **Settings → Rules → New ruleset** in the repository, targeting the `cli-v*` tag pattern and limiting push access to admins or maintainers. This ensures only authorized collaborators can trigger a publish.
+
+### Required secret
+
+The `NPM_TOKEN` secret must be set in the repository settings with publish access to the `webperf-snippets` npm package.
+
 ## Known limitations (v0.1)
 
 - **No INP**: INP requires real user interactions. v0.2 will support synthetic interaction scripts.

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,9 +3,7 @@
   "version": "0.1.0",
   "description": "Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes.",
   "type": "module",
-  "bin": {
-    "webperf-snippets": "./src/bin.js"
-  },
+  "bin": "./src/bin.js",
   "files": [
     "src",
     "snippets",
@@ -36,6 +34,9 @@
   ],
   "author": "Joan Leon | @nucliweb",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nucliweb/webperf-snippets.git",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "webperf-snippets",
+  "version": "0.1.0",
+  "description": "Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes.",
+  "type": "module",
+  "bin": {
+    "webperf-snippets": "./src/bin.js"
+  },
+  "files": [
+    "src",
+    "snippets",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20.12.0"
+  },
+  "keywords": [
+    "webperf",
+    "performance",
+    "core-web-vitals",
+    "lcp",
+    "cls",
+    "inp",
+    "playwright",
+    "cli",
+    "ci"
+  ],
+  "author": "Joan Leon | @nucliweb",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/nucliweb/webperf-snippets.git",
+    "directory": "cli"
+  },
+  "homepage": "https://webperf-snippets.nucliweb.net",
+  "peerDependencies": {
+    "playwright": ">=1.40.0"
+  },
+  "peerDependenciesMeta": {
+    "playwright": {
+      "optional": false
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -11,6 +11,15 @@
     "snippets",
     "README.md"
   ],
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:unit": "vitest run tests/unit",
+    "test:e2e": "vitest run tests/e2e"
+  },
+  "devDependencies": {
+    "vitest": "^2.0.0"
+  },
   "engines": {
     "node": ">=20.12.0"
   },

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -26,7 +26,7 @@ Run curated WebPerf Snippets headlessly via Playwright.
 
 Options:
   --workflow <name>     Workflow to run (default: core-web-vitals)
-  --snippet <name>      Run a single snippet (e.g. LCP, CLS, or Category/Name)
+  --snippet <name>      Run a single snippet (e.g. LCP, CLS, LCP-Subparts, fonts, or Category/Name)
   --json                Output JSON instead of formatted text
   --viewport <preset>   Viewport preset: mobile (default), tablet, desktop
   --wait <ms>           Post-load wait before evaluating (default: 3000)

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import { parseArgs } from "node:util";
+import { loadSnippet } from "./load-snippet.js";
+import { runSnippets } from "./runner.js";
+import { cwvWorkflow } from "./workflows/cwv.js";
+import { nextSteps } from "./decision-tree.js";
+import { reportHuman } from "./reporters/human.js";
+import { reportJson } from "./reporters/json.js";
+
+const WORKFLOWS = {
+  "core-web-vitals": cwvWorkflow,
+};
+
+const SNIPPET_ALIASES = {
+  LCP: "CoreWebVitals/LCP",
+  CLS: "CoreWebVitals/CLS",
+  "LCP-Sub-Parts": "CoreWebVitals/LCP-Sub-Parts",
+};
+
+const USAGE = `webperf-snippets <url> [options]
+
+Run curated WebPerf Snippets headlessly via Playwright.
+
+Options:
+  --workflow <name>     Workflow to run (default: core-web-vitals)
+  --snippet <name>      Run a single snippet (e.g. LCP, CLS, or Category/Name)
+  --json                Output JSON instead of formatted text
+  --wait <ms>           Post-load wait before evaluating (default: 3000)
+  --budget-lcp <ms>     Exit 1 if LCP exceeds this value
+  --budget-cls <score>  Exit 1 if CLS exceeds this value
+  --headed              Show the browser window (debug)
+  -h, --help            Show this help
+
+Examples:
+  npx webperf-snippets https://web.dev
+  npx webperf-snippets https://example.com --json
+  npx webperf-snippets https://example.com --snippet LCP-Sub-Parts
+  npx webperf-snippets https://example.com --budget-lcp 2500
+`;
+
+function fail(message, code = 2) {
+  process.stderr.write(`${message}\n`);
+  process.exit(code);
+}
+
+function resolveSnippetPath(name) {
+  return SNIPPET_ALIASES[name] ?? name;
+}
+
+function buildItems(values) {
+  if (values.snippet) {
+    const path = resolveSnippetPath(values.snippet);
+    return [{ id: values.snippet, path, source: loadSnippet(path) }];
+  }
+  const workflowName = values.workflow ?? "core-web-vitals";
+  const workflow = WORKFLOWS[workflowName];
+  if (!workflow) fail(`Unknown workflow: ${workflowName}`);
+  return workflow.steps.map((step) => ({
+    id: step.id,
+    path: step.path,
+    source: loadSnippet(step.path),
+  }));
+}
+
+function checkBudgets(results, values) {
+  const violations = [];
+  const lcpBudget = values["budget-lcp"] ? Number(values["budget-lcp"]) : null;
+  const clsBudget = values["budget-cls"] ? Number(values["budget-cls"]) : null;
+
+  for (const r of results) {
+    if (r.status !== "ok") continue;
+    if (r.metric === "LCP" && lcpBudget != null && r.value > lcpBudget) {
+      violations.push(`LCP ${r.value}ms exceeds budget ${lcpBudget}ms`);
+    }
+    if (r.metric === "CLS" && clsBudget != null && r.value > clsBudget) {
+      violations.push(`CLS ${r.value} exceeds budget ${clsBudget}`);
+    }
+  }
+  return violations;
+}
+
+async function main() {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      options: {
+        workflow: { type: "string" },
+        snippet: { type: "string" },
+        json: { type: "boolean" },
+        wait: { type: "string" },
+        "budget-lcp": { type: "string" },
+        "budget-cls": { type: "string" },
+        headed: { type: "boolean" },
+        help: { type: "boolean", short: "h" },
+      },
+      allowPositionals: true,
+    });
+  } catch (err) {
+    fail(err.message);
+  }
+
+  const { values, positionals } = parsed;
+
+  if (values.help) {
+    process.stdout.write(USAGE);
+    return;
+  }
+
+  const url = positionals[0];
+  if (!url) {
+    process.stdout.write(USAGE);
+    process.exit(2);
+  }
+
+  const items = buildItems(values);
+  const waitMs = values.wait ? Number(values.wait) : 3000;
+
+  const initial = await runSnippets({
+    url,
+    items,
+    waitMs,
+    headless: !values.headed,
+  });
+
+  // Apply decision tree to spawn follow-up steps.
+  const followUps = nextSteps(initial.results);
+  let followUpRun = { results: [], pageErrors: [] };
+  if (followUps.length > 0) {
+    const followItems = followUps.map((f) => ({
+      id: f.id,
+      path: f.path,
+      source: loadSnippet(f.path),
+      reason: f.reason,
+    }));
+    // v0.1 limitation: follow-ups re-navigate. Acceptable for now; consolidate
+    // into a single page session in v0.2 if perf becomes a problem.
+    followUpRun = await runSnippets({
+      url,
+      items: followItems,
+      waitMs,
+      headless: !values.headed,
+    });
+    // Carry forward the human-readable reason so reporters can show it.
+    followUpRun.results = followUpRun.results.map((r) => {
+      const f = followUps.find((x) => x.id === r.id);
+      return f ? { ...r, reason: f.reason } : r;
+    });
+  }
+
+  const payload = {
+    url,
+    navMs: initial.navMs,
+    results: [...initial.results, ...followUpRun.results],
+    pageErrors: [...initial.pageErrors, ...(followUpRun.pageErrors ?? [])],
+  };
+
+  const output = values.json ? reportJson(payload) : reportHuman(payload);
+  process.stdout.write(output + "\n");
+
+  // Exit codes.
+  const violations = checkBudgets(payload.results, values);
+  if (violations.length > 0) {
+    if (!values.json) {
+      for (const v of violations) process.stderr.write(`Budget violation: ${v}\n`);
+    }
+    process.exit(1);
+  }
+
+  const anyError = payload.results.some((r) => r.status === "error");
+  process.exit(anyError ? 1 : 0);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Error: ${err.stack ?? err.message}\n`);
+  process.exit(1);
+});

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -15,6 +15,9 @@ const SNIPPET_ALIASES = {
   LCP: "CoreWebVitals/LCP",
   CLS: "CoreWebVitals/CLS",
   "LCP-Sub-Parts": "CoreWebVitals/LCP-Sub-Parts",
+  fonts: "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
+  "Fonts-Preloaded-Loaded-and-used-above-the-fold":
+    "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
 };
 
 const USAGE = `webperf-snippets <url> [options]
@@ -36,6 +39,7 @@ Examples:
   npx webperf-snippets https://web.dev
   npx webperf-snippets https://example.com --json
   npx webperf-snippets https://example.com --snippet LCP-Sub-Parts
+  npx webperf-snippets https://example.com --snippet fonts
   npx webperf-snippets https://example.com --budget-lcp 2500
 `;
 

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -65,17 +65,18 @@ Options:
   --wait <ms>           Post-load wait before evaluating (default: 3000)
   --budget-lcp <ms>     Exit 1 if LCP exceeds this value
   --budget-cls <score>  Exit 1 if CLS exceeds this value
+  --verbose             Show all items, even for passing checks
   --headed              Show the browser window (debug)
   -h, --help            Show this help
 
 Examples:
   npx webperf-snippets https://web.dev
-  npx webperf-snippets https://example.com --workflow audit
-  npx webperf-snippets https://example.com --json
-  npx webperf-snippets https://example.com --snippet LCP-Subparts
-  npx webperf-snippets https://example.com --snippet render-blocking
-  npx webperf-snippets https://example.com --snippet fonts
-  npx webperf-snippets https://example.com --budget-lcp 2500
+  npx webperf-snippets https://web.dev --workflow audit
+  npx webperf-snippets https://web.dev --json
+  npx webperf-snippets https://web.dev --snippet LCP-Subparts
+  npx webperf-snippets https://web.dev --snippet render-blocking
+  npx webperf-snippets https://web.dev --snippet fonts
+  npx webperf-snippets https://web.dev --budget-lcp 2500
 `;
 
 function fail(message, code = 2) {
@@ -131,6 +132,7 @@ async function main() {
         "budget-lcp": { type: "string" },
         "budget-cls": { type: "string" },
         viewport: { type: "string" },
+        verbose: { type: "boolean" },
         headed: { type: "boolean" },
         help: { type: "boolean", short: "h" },
       },
@@ -202,7 +204,7 @@ async function main() {
     pageErrors: [...initial.pageErrors, ...(followUpRun.pageErrors ?? [])],
   };
 
-  const output = values.json ? reportJson(payload) : reportHuman(payload);
+  const output = values.json ? reportJson(payload) : reportHuman({ ...payload, verbose: values.verbose });
   process.stdout.write(output + "\n");
 
   // Exit codes.

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -3,12 +3,14 @@ import { parseArgs } from "node:util";
 import { loadSnippet } from "./load-snippet.js";
 import { runSnippets, VIEWPORT_PRESETS } from "./runner.js";
 import { cwvWorkflow } from "./workflows/cwv.js";
+import { auditWorkflow } from "./workflows/audit.js";
 import { nextSteps } from "./decision-tree.js";
 import { reportHuman } from "./reporters/human.js";
 import { reportJson } from "./reporters/json.js";
 
 const WORKFLOWS = {
   "core-web-vitals": cwvWorkflow,
+  audit: auditWorkflow,
 };
 
 const SNIPPET_ALIASES = {
@@ -18,6 +20,31 @@ const SNIPPET_ALIASES = {
   fonts: "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
   "Fonts-Preloaded-Loaded-and-used-above-the-fold":
     "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
+  // Tier 1 — Loading
+  "render-blocking": "Loading/Find-render-blocking-resources",
+  "Find-render-blocking-resources": "Loading/Find-render-blocking-resources",
+  "resource-hints": "Loading/Resource-Hints-Validation",
+  "Resource-Hints-Validation": "Loading/Resource-Hints-Validation",
+  "preload-scripts": "Loading/Validate-Preload-Async-Defer-Scripts",
+  "Validate-Preload-Async-Defer-Scripts": "Loading/Validate-Preload-Async-Defer-Scripts",
+  "priority-hints": "Loading/Priority-Hints-Audit",
+  "Priority-Hints-Audit": "Loading/Priority-Hints-Audit",
+  "critical-css": "Loading/Critical-CSS-Detection",
+  "Critical-CSS-Detection": "Loading/Critical-CSS-Detection",
+  ttfb: "Loading/TTFB-Sub-Parts",
+  "TTFB-Sub-Parts": "Loading/TTFB-Sub-Parts",
+  "script-parties": "Loading/First-And-Third-Party-Script-Info",
+  "First-And-Third-Party-Script-Info": "Loading/First-And-Third-Party-Script-Info",
+  "script-loading": "Loading/Script-Loading",
+  "Script-Loading": "Loading/Script-Loading",
+  // Tier 2 — Media
+  "lazy-atf": "Loading/Find-Above-The-Fold-Lazy-Loaded-Images",
+  "Find-Above-The-Fold-Lazy-Loaded-Images": "Loading/Find-Above-The-Fold-Lazy-Loaded-Images",
+  "lazy-conflict": "Loading/Find-Images-With-Lazy-and-Fetchpriority",
+  "Find-Images-With-Lazy-and-Fetchpriority": "Loading/Find-Images-With-Lazy-and-Fetchpriority",
+  "eager-below-fold": "Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport",
+  "Find-non-Lazy-Loaded-Images-outside-of-the-viewport":
+    "Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport",
 };
 
 const USAGE = `webperf-snippets <url> [options]
@@ -26,7 +53,13 @@ Run curated WebPerf Snippets headlessly via Playwright.
 
 Options:
   --workflow <name>     Workflow to run (default: core-web-vitals)
-  --snippet <name>      Run a single snippet (e.g. LCP, CLS, LCP-Subparts, fonts, or Category/Name)
+                        Workflows: core-web-vitals, audit
+  --snippet <name>      Run a single snippet by alias or Category/Name path
+                        Aliases: LCP, CLS, LCP-Subparts, fonts,
+                                 render-blocking, resource-hints, preload-scripts,
+                                 priority-hints, critical-css, ttfb,
+                                 script-parties, script-loading,
+                                 lazy-atf, lazy-conflict, eager-below-fold
   --json                Output JSON instead of formatted text
   --viewport <preset>   Viewport preset: mobile (default), tablet, desktop
   --wait <ms>           Post-load wait before evaluating (default: 3000)
@@ -37,8 +70,10 @@ Options:
 
 Examples:
   npx webperf-snippets https://web.dev
+  npx webperf-snippets https://example.com --workflow audit
   npx webperf-snippets https://example.com --json
   npx webperf-snippets https://example.com --snippet LCP-Subparts
+  npx webperf-snippets https://example.com --snippet render-blocking
   npx webperf-snippets https://example.com --snippet fonts
   npx webperf-snippets https://example.com --budget-lcp 2500
 `;
@@ -180,7 +215,10 @@ async function main() {
   }
 
   const anyError = payload.results.some((r) => r.status === "error");
-  process.exit(anyError ? 1 : 0);
+  const anyAuditViolation = payload.results.some(
+    (r) => Array.isArray(r.issues) && r.issues.some((i) => i.severity === "error"),
+  );
+  process.exit(anyError || anyAuditViolation ? 1 : 0);
 }
 
 main().catch((err) => {

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from "node:util";
 import { loadSnippet } from "./load-snippet.js";
-import { runSnippets } from "./runner.js";
+import { runSnippets, VIEWPORT_PRESETS } from "./runner.js";
 import { cwvWorkflow } from "./workflows/cwv.js";
 import { nextSteps } from "./decision-tree.js";
 import { reportHuman } from "./reporters/human.js";
@@ -25,6 +25,7 @@ Options:
   --workflow <name>     Workflow to run (default: core-web-vitals)
   --snippet <name>      Run a single snippet (e.g. LCP, CLS, or Category/Name)
   --json                Output JSON instead of formatted text
+  --viewport <preset>   Viewport preset: mobile (default), tablet, desktop
   --wait <ms>           Post-load wait before evaluating (default: 3000)
   --budget-lcp <ms>     Exit 1 if LCP exceeds this value
   --budget-cls <score>  Exit 1 if CLS exceeds this value
@@ -90,6 +91,7 @@ async function main() {
         wait: { type: "string" },
         "budget-lcp": { type: "string" },
         "budget-cls": { type: "string" },
+        viewport: { type: "string" },
         headed: { type: "boolean" },
         help: { type: "boolean", short: "h" },
       },
@@ -114,12 +116,18 @@ async function main() {
 
   const items = buildItems(values);
   const waitMs = values.wait ? Number(values.wait) : 3000;
+  const viewportName = values.viewport ?? "mobile";
+  const viewport = VIEWPORT_PRESETS[viewportName];
+  if (!viewport) {
+    fail(`Unknown viewport preset: "${viewportName}". Choose from: ${Object.keys(VIEWPORT_PRESETS).join(", ")}`);
+  }
 
   const initial = await runSnippets({
     url,
     items,
     waitMs,
     headless: !values.headed,
+    viewport,
   });
 
   // Apply decision tree to spawn follow-up steps.
@@ -139,6 +147,7 @@ async function main() {
       items: followItems,
       waitMs,
       headless: !values.headed,
+      viewport,
     });
     // Carry forward the human-readable reason so reporters can show it.
     followUpRun.results = followUpRun.results.map((r) => {

--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -14,7 +14,7 @@ const WORKFLOWS = {
 const SNIPPET_ALIASES = {
   LCP: "CoreWebVitals/LCP",
   CLS: "CoreWebVitals/CLS",
-  "LCP-Sub-Parts": "CoreWebVitals/LCP-Sub-Parts",
+  "LCP-Subparts": "CoreWebVitals/LCP-Subparts",
   fonts: "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
   "Fonts-Preloaded-Loaded-and-used-above-the-fold":
     "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold",
@@ -38,7 +38,7 @@ Options:
 Examples:
   npx webperf-snippets https://web.dev
   npx webperf-snippets https://example.com --json
-  npx webperf-snippets https://example.com --snippet LCP-Sub-Parts
+  npx webperf-snippets https://example.com --snippet LCP-Subparts
   npx webperf-snippets https://example.com --snippet fonts
   npx webperf-snippets https://example.com --budget-lcp 2500
 `;

--- a/cli/src/decision-tree.js
+++ b/cli/src/decision-tree.js
@@ -3,7 +3,7 @@
 const RULES = [
   {
     when: (r) => r.id === "LCP" && r.status === "ok" && r.value > 2500,
-    append: { id: "LCP-Sub-Parts", path: "CoreWebVitals/LCP-Sub-Parts" },
+    append: { id: "LCP-Subparts", path: "CoreWebVitals/LCP-Subparts" },
     reason: "LCP > 2.5s — drilling into sub-parts",
   },
 ];

--- a/cli/src/decision-tree.js
+++ b/cli/src/decision-tree.js
@@ -1,0 +1,19 @@
+// Declarative follow-ups: if a result matches the predicate, append the step.
+// Mirrors the WORKFLOWS.md decision trees from the snippet catalogue.
+const RULES = [
+  {
+    when: (r) => r.id === "LCP" && r.status === "ok" && r.value > 2500,
+    append: { id: "LCP-Sub-Parts", path: "CoreWebVitals/LCP-Sub-Parts" },
+    reason: "LCP > 2.5s — drilling into sub-parts",
+  },
+];
+
+export function nextSteps(results) {
+  const followUps = [];
+  for (const result of results) {
+    for (const rule of RULES) {
+      if (rule.when(result)) followUps.push({ ...rule.append, reason: rule.reason });
+    }
+  }
+  return followUps;
+}

--- a/cli/src/load-snippet.js
+++ b/cli/src/load-snippet.js
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = resolve(HERE, "..");
+
+// Resolution order: bundled (published package) → workspace root (dev).
+const SNIPPET_DIRS = [
+  join(PKG_ROOT, "snippets"),
+  resolve(PKG_ROOT, "..", "snippets"),
+];
+
+export function loadSnippet(relativePath) {
+  for (const dir of SNIPPET_DIRS) {
+    try {
+      return readFileSync(join(dir, `${relativePath}.js`), "utf8");
+    } catch {
+      // try next directory
+    }
+  }
+  throw new Error(`Snippet not found: ${relativePath}`);
+}

--- a/cli/src/reporters/human.js
+++ b/cli/src/reporters/human.js
@@ -29,9 +29,56 @@ function pad(text, len) {
   return text + " ".repeat(Math.max(0, len - visibleLen));
 }
 
+const DISPLAY_WARN = new Set(["block", "auto", "unknown"]);
+
+function renderFontsResult(r) {
+  const d = r.details ?? {};
+  const lines = [];
+
+  lines.push(styleText("bold", `  Fonts — preloaded: ${d.preloadedCount ?? 0}  loaded: ${d.loadedCount ?? 0}  used above fold: ${d.usedAboveFoldCount ?? 0}`));
+
+  if (r.items?.length) {
+    lines.push("");
+    lines.push(styleText("dim", "  Loaded fonts:"));
+    lines.push(styleText("dim", `    ${"Family".padEnd(20)} ${"Weight".padEnd(8)} ${"Style".padEnd(10)} Display`));
+    for (const f of r.items) {
+      const displayWarning = DISPLAY_WARN.has(f.display) ? styleText("yellow", ` ⚠ ${f.display}`) : styleText("green", ` ${f.display}`);
+      lines.push(`    ${f.family.padEnd(20)} ${f.weight.padEnd(8)} ${f.style.padEnd(10)}${displayWarning}`);
+    }
+  }
+
+  if (r.usedFonts?.length) {
+    lines.push("");
+    lines.push(styleText("dim", "  Used above fold:"));
+    lines.push(styleText("dim", `    ${"Family".padEnd(20)} ${"Weight".padEnd(8)} ${"Style".padEnd(10)} Elements`));
+    const sorted = [...r.usedFonts].sort((a, b) => b.elements - a.elements);
+    for (const f of sorted) {
+      lines.push(`    ${f.family.padEnd(20)} ${f.weight.padEnd(8)} ${f.style.padEnd(10)} ${f.elements}`);
+    }
+  }
+
+  if (r.issues?.length) {
+    lines.push("");
+    lines.push(styleText("dim", "  Issues:"));
+    for (const issue of r.issues) {
+      const color = issue.severity === "error" ? "red" : "yellow";
+      lines.push(`    ${styleText(color, issue.severity === "error" ? "✗" : "⚠")} ${issue.message}`);
+    }
+  } else {
+    lines.push("");
+    lines.push(`    ${styleText("green", "✓")} Font loading looks optimized`);
+  }
+
+  return lines.join("\n");
+}
+
 function renderResult(r) {
   if (r.status === "error") {
     return `  ${styleText("red", "✗")} ${pad(r.id, 16)} ${styleText("dim", r.error)}`;
+  }
+
+  if (Array.isArray(r.issues)) {
+    return renderFontsResult(r);
   }
 
   const icon = RATING_ICON[r.rating] ?? "·";

--- a/cli/src/reporters/human.js
+++ b/cli/src/reporters/human.js
@@ -72,7 +72,7 @@ function renderFontsResult(r) {
   return lines.join("\n");
 }
 
-function renderAuditResult(r) {
+function renderAuditResult(r, verbose) {
   const lines = [];
   const id = r.id ?? r.script;
   const errors = (r.issues ?? []).filter((i) => i.severity === "error");
@@ -92,14 +92,15 @@ function renderAuditResult(r) {
     lines.push(`     ${styleText("green", "✓")} No issues`);
   }
 
+  const isGreen = errors.length === 0 && warnings.length === 0;
   const MAX_ITEMS = 10;
   const items = r.items ?? [];
-  if (items.length > 0) {
+  if (items.length > 0 && (!isGreen || verbose)) {
     lines.push("");
     const shown = items.slice(0, MAX_ITEMS);
     for (const item of shown) {
-      const name = item.shortName ?? item.resource ?? item.url ?? item.src ?? item.selector ?? "";
-      const tag = item.type ?? item.tag ?? item.strategy ?? "";
+      const name = item.shortName ?? item.resource ?? item.url ?? item.src ?? item.selector ?? item.filename ?? "";
+      const tag = item.type ?? item.tag ?? item.strategy ?? item.media ?? "";
       const timing = item.responseEndMs != null ? `${item.responseEndMs}ms` : item.durationMs != null ? `${item.durationMs}ms` : "";
       const cols = [tag, name, timing].filter(Boolean).join("  ");
       lines.push(`     ${styleText("dim", `· ${cols}`)}`);
@@ -116,7 +117,7 @@ function renderAuditResult(r) {
   return lines.join("\n");
 }
 
-function renderResult(r) {
+function renderResult(r, verbose) {
   if (r.status === "error") {
     return `  ${styleText("red", "✗")} ${pad(r.id, 16)} ${styleText("dim", r.error)}`;
   }
@@ -126,7 +127,7 @@ function renderResult(r) {
   }
 
   if (Array.isArray(r.issues)) {
-    return renderAuditResult(r);
+    return renderAuditResult(r, verbose);
   }
 
   const icon = RATING_ICON[r.rating] ?? "·";
@@ -163,12 +164,12 @@ function renderResult(r) {
   return out;
 }
 
-export function reportHuman({ url, navMs, results, pageErrors }) {
+export function reportHuman({ url, navMs, results, pageErrors, verbose }) {
   const lines = [];
   lines.push(styleText(["bold"], `WebPerf Snippets — ${url}`));
   lines.push(styleText("dim", `Navigated in ${navMs}ms`));
   lines.push("");
-  for (const r of results) lines.push(renderResult(r));
+  for (const r of results) lines.push(renderResult(r, verbose));
   if (pageErrors?.length) {
     lines.push("");
     lines.push(styleText("yellow", "Page errors during run:"));

--- a/cli/src/reporters/human.js
+++ b/cli/src/reporters/human.js
@@ -1,0 +1,83 @@
+import { styleText } from "node:util";
+
+const RATING_ICON = {
+  good: "🟢",
+  "needs-improvement": "🟡",
+  poor: "🔴",
+};
+
+const RATING_STYLE = {
+  good: "green",
+  "needs-improvement": "yellow",
+  poor: "red",
+};
+
+function formatValue(value, unit) {
+  if (unit === "ms") {
+    return value >= 1000 ? `${(value / 1000).toFixed(2)}s` : `${value}ms`;
+  }
+  if (unit === "score") return value.toFixed(4);
+  return String(value);
+}
+
+function paint(rating, text) {
+  return styleText(RATING_STYLE[rating] ?? "white", text);
+}
+
+function pad(text, len) {
+  const visibleLen = text.replace(/\[\d+m/g, "").length;
+  return text + " ".repeat(Math.max(0, len - visibleLen));
+}
+
+function renderResult(r) {
+  if (r.status === "error") {
+    return `  ${styleText("red", "✗")} ${pad(r.id, 16)} ${styleText("dim", r.error)}`;
+  }
+
+  const icon = RATING_ICON[r.rating] ?? "·";
+  const valueText = paint(r.rating, formatValue(r.value, r.unit));
+  const ratingText = styleText("dim", r.rating ?? "");
+  const detail = r.details?.element ? styleText("dim", r.details.element) : "";
+
+  let out = `  ${icon} ${pad(r.id, 16)} ${pad(valueText, 10)} ${pad(ratingText, 20)} ${detail}`;
+
+  if (r.details?.subParts) {
+    const sp = r.details.subParts;
+    const rows = [
+      ["TTFB", sp.ttfb],
+      ["Resource Load Delay", sp.resourceLoadDelay],
+      ["Resource Load Time", sp.resourceLoadTime],
+      ["Element Render Delay", sp.elementRenderDelay],
+    ];
+    out += "\n";
+    out += rows
+      .map(([name, info]) => {
+        const status = info.overTarget ? styleText("red", "🔴") : styleText("green", "✓");
+        return `       ${status} ${pad(name, 22)} ${pad(`${info.value}ms`, 8)} ${pad(`${info.percent}%`, 6)}`;
+      })
+      .join("\n");
+    if (r.details.slowestPhase) {
+      out += `\n       ${styleText("blue", "→ Slowest:")} ${r.details.slowestPhase}`;
+    }
+  }
+
+  if (r.reason) {
+    out += `\n     ${styleText("dim", `↳ ${r.reason}`)}`;
+  }
+
+  return out;
+}
+
+export function reportHuman({ url, navMs, results, pageErrors }) {
+  const lines = [];
+  lines.push(styleText(["bold"], `WebPerf Snippets — ${url}`));
+  lines.push(styleText("dim", `Navigated in ${navMs}ms`));
+  lines.push("");
+  for (const r of results) lines.push(renderResult(r));
+  if (pageErrors?.length) {
+    lines.push("");
+    lines.push(styleText("yellow", "Page errors during run:"));
+    for (const err of pageErrors) lines.push(`  ${styleText("dim", err)}`);
+  }
+  return lines.join("\n");
+}

--- a/cli/src/reporters/human.js
+++ b/cli/src/reporters/human.js
@@ -72,13 +72,61 @@ function renderFontsResult(r) {
   return lines.join("\n");
 }
 
+function renderAuditResult(r) {
+  const lines = [];
+  const id = r.id ?? r.script;
+  const errors = (r.issues ?? []).filter((i) => i.severity === "error");
+  const warnings = (r.issues ?? []).filter((i) => i.severity === "warning");
+
+  const icon = errors.length ? "🔴" : warnings.length ? "🟡" : "🟢";
+  const countSuffix = r.count > 0 ? styleText("dim", ` (${r.count})`) : "";
+  lines.push(`  ${icon} ${id}${countSuffix}`);
+
+  if (r.issues?.length) {
+    for (const issue of r.issues) {
+      const color = issue.severity === "error" ? "red" : issue.severity === "warning" ? "yellow" : "blue";
+      const sym = issue.severity === "error" ? "✗" : issue.severity === "warning" ? "⚠" : "ℹ";
+      lines.push(`     ${styleText(color, sym)} ${issue.message}`);
+    }
+  } else {
+    lines.push(`     ${styleText("green", "✓")} No issues`);
+  }
+
+  const MAX_ITEMS = 10;
+  const items = r.items ?? [];
+  if (items.length > 0) {
+    lines.push("");
+    const shown = items.slice(0, MAX_ITEMS);
+    for (const item of shown) {
+      const name = item.shortName ?? item.resource ?? item.url ?? item.src ?? item.selector ?? "";
+      const tag = item.type ?? item.tag ?? item.strategy ?? "";
+      const timing = item.responseEndMs != null ? `${item.responseEndMs}ms` : item.durationMs != null ? `${item.durationMs}ms` : "";
+      const cols = [tag, name, timing].filter(Boolean).join("  ");
+      lines.push(`     ${styleText("dim", `· ${cols}`)}`);
+    }
+    if (items.length > MAX_ITEMS) {
+      lines.push(`     ${styleText("dim", `… and ${items.length - MAX_ITEMS} more`)}`);
+    }
+  }
+
+  if (r.reason) {
+    lines.push(`     ${styleText("dim", `↳ ${r.reason}`)}`);
+  }
+
+  return lines.join("\n");
+}
+
 function renderResult(r) {
   if (r.status === "error") {
     return `  ${styleText("red", "✗")} ${pad(r.id, 16)} ${styleText("dim", r.error)}`;
   }
 
-  if (Array.isArray(r.issues)) {
+  if (r.script === "Fonts-Preloaded-Loaded-and-used-above-the-fold") {
     return renderFontsResult(r);
+  }
+
+  if (Array.isArray(r.issues)) {
+    return renderAuditResult(r);
   }
 
   const icon = RATING_ICON[r.rating] ?? "·";
@@ -88,7 +136,7 @@ function renderResult(r) {
 
   let out = `  ${icon} ${pad(r.id, 16)} ${pad(valueText, 10)} ${pad(ratingText, 20)} ${detail}`;
 
-  if (r.details?.subParts) {
+  if (r.metric === "LCP" && r.details?.subParts) {
     const sp = r.details.subParts;
     const rows = [
       ["TTFB", sp.ttfb],

--- a/cli/src/reporters/json.js
+++ b/cli/src/reporters/json.js
@@ -1,0 +1,3 @@
+export function reportJson(payload) {
+  return JSON.stringify(payload, null, 2);
+}

--- a/cli/src/runner.js
+++ b/cli/src/runner.js
@@ -1,0 +1,86 @@
+import { chromium } from "playwright";
+
+const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
+const DEFAULT_NAV_TIMEOUT = 30000;
+
+// Chrome does not expose largest-contentful-paint or layout-shift entries via
+// performance.getEntriesByType — they are only delivered through observers.
+// The snippets' synchronous return path assumes otherwise (works in
+// long-lived consoles where entries leaked into the timeline). To make
+// snippets work unmodified in headless, we capture entries via a pre-nav
+// observer and shim getEntriesByType to return them.
+const WARMUP_SCRIPT = `
+(() => {
+  window.__wps = { lcp: [], layoutShift: [] };
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) window.__wps.lcp.push(e);
+    }).observe({ type: "largest-contentful-paint", buffered: true });
+  } catch {}
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) window.__wps.layoutShift.push(e);
+    }).observe({ type: "layout-shift", buffered: true });
+  } catch {}
+
+  const orig = performance.getEntriesByType.bind(performance);
+  performance.getEntriesByType = function (type) {
+    if (type === "largest-contentful-paint") return window.__wps.lcp.slice();
+    if (type === "layout-shift") return window.__wps.layoutShift.slice();
+    return orig(type);
+  };
+})();
+`;
+
+// Snippets are IIFEs. Playwright evaluates a string as an expression, so we
+// trim trailing semicolons to keep the IIFE call as a single expression and
+// recover its return value in Node.
+function toExpression(source) {
+  return source.trim().replace(/;\s*$/, "");
+}
+
+export async function runSnippets({
+  url,
+  items,
+  waitMs = 3000,
+  headless = true,
+  viewport = DEFAULT_VIEWPORT,
+  navTimeout = DEFAULT_NAV_TIMEOUT,
+}) {
+  const browser = await chromium.launch({ headless });
+  try {
+    const context = await browser.newContext({ viewport });
+    await context.addInitScript(WARMUP_SCRIPT);
+    const page = await context.newPage();
+
+    const pageErrors = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    const navStart = Date.now();
+    await page.goto(url, { waitUntil: "load", timeout: navTimeout });
+    if (waitMs > 0) await page.waitForTimeout(waitMs);
+    const navMs = Date.now() - navStart;
+
+    const results = [];
+    for (const item of items) {
+      try {
+        const result = await page.evaluate(toExpression(item.source));
+        if (result && typeof result === "object") {
+          results.push({ id: item.id, ...result });
+        } else {
+          results.push({
+            id: item.id,
+            status: "error",
+            error: "Snippet did not return an object — check the IIFE return statement",
+          });
+        }
+      } catch (err) {
+        results.push({ id: item.id, status: "error", error: err.message });
+      }
+    }
+
+    return { url, navMs, results, pageErrors };
+  } finally {
+    await browser.close();
+  }
+}

--- a/cli/src/runner.js
+++ b/cli/src/runner.js
@@ -1,6 +1,11 @@
 import { chromium } from "playwright";
 
-const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
+export const VIEWPORT_PRESETS = {
+  mobile: { width: 375, height: 812 },
+  tablet: { width: 768, height: 1024 },
+  desktop: { width: 1280, height: 800 },
+};
+
 const DEFAULT_NAV_TIMEOUT = 30000;
 
 // Snippets are IIFEs. Playwright evaluates a string as an expression, so we
@@ -15,7 +20,7 @@ export async function runSnippets({
   items,
   waitMs = 3000,
   headless = true,
-  viewport = DEFAULT_VIEWPORT,
+  viewport = VIEWPORT_PRESETS.mobile,
   navTimeout = DEFAULT_NAV_TIMEOUT,
 }) {
   const browser = await chromium.launch({ headless });

--- a/cli/src/runner.js
+++ b/cli/src/runner.js
@@ -3,35 +3,6 @@ import { chromium } from "playwright";
 const DEFAULT_VIEWPORT = { width: 1280, height: 800 };
 const DEFAULT_NAV_TIMEOUT = 30000;
 
-// Chrome does not expose largest-contentful-paint or layout-shift entries via
-// performance.getEntriesByType — they are only delivered through observers.
-// The snippets' synchronous return path assumes otherwise (works in
-// long-lived consoles where entries leaked into the timeline). To make
-// snippets work unmodified in headless, we capture entries via a pre-nav
-// observer and shim getEntriesByType to return them.
-const WARMUP_SCRIPT = `
-(() => {
-  window.__wps = { lcp: [], layoutShift: [] };
-  try {
-    new PerformanceObserver((list) => {
-      for (const e of list.getEntries()) window.__wps.lcp.push(e);
-    }).observe({ type: "largest-contentful-paint", buffered: true });
-  } catch {}
-  try {
-    new PerformanceObserver((list) => {
-      for (const e of list.getEntries()) window.__wps.layoutShift.push(e);
-    }).observe({ type: "layout-shift", buffered: true });
-  } catch {}
-
-  const orig = performance.getEntriesByType.bind(performance);
-  performance.getEntriesByType = function (type) {
-    if (type === "largest-contentful-paint") return window.__wps.lcp.slice();
-    if (type === "layout-shift") return window.__wps.layoutShift.slice();
-    return orig(type);
-  };
-})();
-`;
-
 // Snippets are IIFEs. Playwright evaluates a string as an expression, so we
 // trim trailing semicolons to keep the IIFE call as a single expression and
 // recover its return value in Node.
@@ -50,7 +21,6 @@ export async function runSnippets({
   const browser = await chromium.launch({ headless });
   try {
     const context = await browser.newContext({ viewport });
-    await context.addInitScript(WARMUP_SCRIPT);
     const page = await context.newPage();
 
     const pageErrors = [];

--- a/cli/src/workflows/audit.js
+++ b/cli/src/workflows/audit.js
@@ -1,0 +1,21 @@
+// Structural audit workflow — deterministic checks suitable for CI.
+// These snippets return binary pass/fail results with no timing noise.
+export const auditWorkflow = {
+  id: "audit",
+  title: "Structural Audit",
+  steps: [
+    // Tier 1 — Loading determinista
+    { id: "render-blocking", path: "Loading/Find-render-blocking-resources" },
+    { id: "resource-hints", path: "Loading/Resource-Hints-Validation" },
+    { id: "preload-scripts", path: "Loading/Validate-Preload-Async-Defer-Scripts" },
+    { id: "priority-hints", path: "Loading/Priority-Hints-Audit" },
+    { id: "critical-css", path: "Loading/Critical-CSS-Detection" },
+    { id: "ttfb", path: "Loading/TTFB-Sub-Parts" },
+    { id: "script-parties", path: "Loading/First-And-Third-Party-Script-Info" },
+    { id: "script-loading", path: "Loading/Script-Loading" },
+    // Tier 2 — Media determinista
+    { id: "lazy-atf", path: "Loading/Find-Above-The-Fold-Lazy-Loaded-Images" },
+    { id: "lazy-conflict", path: "Loading/Find-Images-With-Lazy-and-Fetchpriority" },
+    { id: "eager-below-fold", path: "Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport" },
+  ],
+};

--- a/cli/src/workflows/cwv.js
+++ b/cli/src/workflows/cwv.js
@@ -1,0 +1,10 @@
+// Core Web Vitals workflow.
+// Snippet IDs map to paths under <repo>/snippets/.
+export const cwvWorkflow = {
+  id: "core-web-vitals",
+  title: "Core Web Vitals",
+  steps: [
+    { id: "LCP", path: "CoreWebVitals/LCP" },
+    { id: "CLS", path: "CoreWebVitals/CLS" },
+  ],
+};

--- a/cli/tests/e2e/audit.test.js
+++ b/cli/tests/e2e/audit.test.js
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { runSnippets, VIEWPORT_PRESETS } from "../../src/runner.js";
+import { loadSnippet } from "../../src/load-snippet.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = join(HERE, "../fixtures");
+
+const GREEN_HTML = readFileSync(join(FIXTURES, "audit-green.html"), "utf8");
+const VIOLATIONS_HTML = readFileSync(join(FIXTURES, "audit-violations.html"), "utf8");
+
+// Minimal 1×1 transparent GIF served for all image requests.
+const PIXEL_GIF = Buffer.from(
+  "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+  "base64"
+);
+
+let server;
+let baseUrl;
+
+beforeAll(
+  () =>
+    new Promise((resolve) => {
+      server = createServer((req, res) => {
+        if (req.url.match(/\.(gif|png|jpg|jpeg|webp|avif)$/)) {
+          res.writeHead(200, { "Content-Type": "image/gif" });
+          res.end(PIXEL_GIF);
+          return;
+        }
+        if (req.url.endsWith(".css")) {
+          res.writeHead(200, { "Content-Type": "text/css" });
+          res.end("body { color: black; font-family: sans-serif; }");
+          return;
+        }
+        if (req.url.endsWith(".js")) {
+          res.writeHead(200, { "Content-Type": "application/javascript" });
+          res.end("// placeholder");
+          return;
+        }
+        const html = req.url === "/violations" ? VIOLATIONS_HTML : GREEN_HTML;
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(html);
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address();
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    }),
+  10000
+);
+
+afterAll(
+  () =>
+    new Promise((resolve) => {
+      server.close(resolve);
+    })
+);
+
+const AUDIT_STEPS = [
+  { id: "render-blocking", path: "Loading/Find-render-blocking-resources" },
+  { id: "resource-hints", path: "Loading/Resource-Hints-Validation" },
+  { id: "preload-scripts", path: "Loading/Validate-Preload-Async-Defer-Scripts" },
+  { id: "priority-hints", path: "Loading/Priority-Hints-Audit" },
+  { id: "critical-css", path: "Loading/Critical-CSS-Detection" },
+  { id: "ttfb", path: "Loading/TTFB-Sub-Parts" },
+  { id: "script-parties", path: "Loading/First-And-Third-Party-Script-Info" },
+  { id: "script-loading", path: "Loading/Script-Loading" },
+  { id: "lazy-atf", path: "Loading/Find-Above-The-Fold-Lazy-Loaded-Images" },
+  { id: "lazy-conflict", path: "Loading/Find-Images-With-Lazy-and-Fetchpriority" },
+  { id: "eager-below-fold", path: "Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport" },
+];
+
+function makeItems(steps) {
+  return steps.map((step) => ({
+    id: step.id,
+    path: step.path,
+    source: loadSnippet(step.path),
+  }));
+}
+
+async function runAudit(url, steps = AUDIT_STEPS) {
+  const { results } = await runSnippets({
+    url,
+    items: makeItems(steps),
+    waitMs: 500,
+    viewport: VIEWPORT_PRESETS.mobile,
+  });
+  return results;
+}
+
+function step(id) {
+  return AUDIT_STEPS.filter((s) => s.id === id);
+}
+
+// ─── Green fixture — expects no violations ────────────────────────────────────
+
+describe("Audit snippets — green fixture (no violations)", () => {
+  it(
+    "all snippets execute without errors",
+    async () => {
+      const results = await runAudit(baseUrl);
+      for (const r of results) {
+        expect(r.status, `${r.id} threw: ${r.error}`).not.toBe("error");
+      }
+    },
+    60000,
+  );
+
+  it(
+    "all non-TTFB snippets return an issues array",
+    async () => {
+      const results = await runAudit(baseUrl);
+      for (const r of results.filter((r) => r.id !== "ttfb")) {
+        expect(Array.isArray(r.issues), `${r.id} missing issues array`).toBe(true);
+      }
+    },
+    60000,
+  );
+
+  it(
+    "TTFB returns a metric with a rating",
+    async () => {
+      const [r] = await runAudit(baseUrl, step("ttfb"));
+      expect(r.status).toBe("ok");
+      expect(r.metric).toBe("TTFB");
+      expect(typeof r.value).toBe("number");
+      expect(["good", "needs-improvement", "poor"]).toContain(r.rating);
+    },
+    30000,
+  );
+
+  it(
+    "render-blocking — 🟢 no blocking resources on a page with only inline styles",
+    async () => {
+      const [r] = await runAudit(baseUrl, step("render-blocking"));
+      // renderBlockingStatus requires Chrome 107+; skip gracefully if unavailable
+      if (r.status === "unsupported") return;
+      expect(r.status).toBe("ok");
+      expect(r.count).toBe(0);
+      expect(r.issues).toEqual([]);
+    },
+    30000,
+  );
+
+  it(
+    "lazy-atf — 🟢 no lazy images above fold",
+    async () => {
+      const [r] = await runAudit(baseUrl, step("lazy-atf"));
+      expect(r.status).toBe("ok");
+      expect(r.count).toBe(0);
+      expect(r.issues).toEqual([]);
+    },
+    30000,
+  );
+
+  it(
+    "lazy-conflict — 🟢 no lazy+fetchpriority conflicts",
+    async () => {
+      const [r] = await runAudit(baseUrl, step("lazy-conflict"));
+      expect(r.status).toBe("ok");
+      expect(r.count).toBe(0);
+      expect(r.issues).toEqual([]);
+    },
+    30000,
+  );
+
+  it(
+    "eager-below-fold — 🟢 all below-fold images are properly lazy",
+    async () => {
+      const [r] = await runAudit(baseUrl, step("eager-below-fold"));
+      expect(r.status).toBe("ok");
+      expect(r.issues).toEqual([]);
+    },
+    30000,
+  );
+});
+
+// ─── Violations fixture — expects specific issues ──────────────────────────────
+
+describe("Audit snippets — violations fixture (deliberate issues)", () => {
+  it(
+    "render-blocking — 🔴 detects the blocking external CSS file",
+    async () => {
+      const [r] = await runAudit(`${baseUrl}/violations`, step("render-blocking"));
+      if (r.status === "unsupported") return;
+      expect(r.status).toBe("ok");
+      expect(r.count).toBeGreaterThan(0);
+      expect(r.issues.some((i) => i.severity === "error")).toBe(true);
+    },
+    30000,
+  );
+
+  it(
+    "lazy-atf — 🔴 detects lazy image above the fold",
+    async () => {
+      const [r] = await runAudit(`${baseUrl}/violations`, step("lazy-atf"));
+      expect(r.status).toBe("ok");
+      expect(r.count).toBeGreaterThan(0);
+      expect(r.issues.length).toBeGreaterThan(0);
+    },
+    30000,
+  );
+
+  it(
+    "lazy-conflict — 🔴 detects image with loading=lazy and fetchpriority=high",
+    async () => {
+      const [r] = await runAudit(`${baseUrl}/violations`, step("lazy-conflict"));
+      expect(r.status).toBe("ok");
+      expect(r.count).toBeGreaterThan(0);
+      expect(r.issues.some((i) => i.severity === "error")).toBe(true);
+    },
+    30000,
+  );
+
+  it(
+    "eager-below-fold — 🟡 detects images below viewport without lazy loading",
+    async () => {
+      const [r] = await runAudit(`${baseUrl}/violations`, step("eager-below-fold"));
+      expect(r.status).toBe("ok");
+      expect(r.count).toBeGreaterThan(0);
+      expect(r.issues.some((i) => i.severity === "warning")).toBe(true);
+    },
+    30000,
+  );
+});

--- a/cli/tests/e2e/cwv.test.js
+++ b/cli/tests/e2e/cwv.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer } from "node:http";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { runSnippets, VIEWPORT_PRESETS } from "../../src/runner.js";
+import { loadSnippet } from "../../src/load-snippet.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_HTML = readFileSync(join(HERE, "../fixtures/index.html"), "utf8");
+
+let server;
+let baseUrl;
+
+beforeAll(
+  () =>
+    new Promise((resolve) => {
+      server = createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(FIXTURE_HTML);
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address();
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    }),
+  10000
+);
+
+afterAll(
+  () =>
+    new Promise((resolve) => {
+      server.close(resolve);
+    })
+);
+
+function makeItems(ids) {
+  return ids.map((id) => ({
+    id,
+    path: `CoreWebVitals/${id}`,
+    source: loadSnippet(`CoreWebVitals/${id}`),
+  }));
+}
+
+describe("Core Web Vitals snippets on a local page", () => {
+  it(
+    "LCP returns a numeric value with a rating",
+    async () => {
+      const { results } = await runSnippets({
+        url: baseUrl,
+        items: makeItems(["LCP"]),
+        waitMs: 500,
+        viewport: VIEWPORT_PRESETS.mobile,
+      });
+
+      const lcp = results.find((r) => r.id === "LCP");
+      expect(lcp.status).toBe("ok");
+      expect(typeof lcp.value).toBe("number");
+      expect(lcp.value).toBeGreaterThanOrEqual(0);
+      expect(["good", "needs-improvement", "poor"]).toContain(lcp.rating);
+      expect(lcp.unit).toBe("ms");
+    },
+    30000
+  );
+
+  it(
+    "CLS returns 0 on a stable page",
+    async () => {
+      const { results } = await runSnippets({
+        url: baseUrl,
+        items: makeItems(["CLS"]),
+        waitMs: 500,
+        viewport: VIEWPORT_PRESETS.mobile,
+      });
+
+      const cls = results.find((r) => r.id === "CLS");
+      expect(cls.status).toBe("ok");
+      expect(cls.value).toBe(0);
+      expect(cls.rating).toBe("good");
+      expect(cls.unit).toBe("score");
+    },
+    30000
+  );
+
+  it(
+    "respects the viewport preset passed to runSnippets",
+    async () => {
+      const { results: mobileResults } = await runSnippets({
+        url: baseUrl,
+        items: makeItems(["LCP"]),
+        waitMs: 500,
+        viewport: VIEWPORT_PRESETS.mobile,
+      });
+      const { results: desktopResults } = await runSnippets({
+        url: baseUrl,
+        items: makeItems(["LCP"]),
+        waitMs: 500,
+        viewport: VIEWPORT_PRESETS.desktop,
+      });
+
+      expect(mobileResults[0].status).toBe("ok");
+      expect(desktopResults[0].status).toBe("ok");
+    },
+    60000
+  );
+});

--- a/cli/tests/fixtures/audit-green.html
+++ b/cli/tests/fixtures/audit-green.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Audit Green — No Violations</title>
+  <!-- Inline styles only: no render-blocking external CSS -->
+  <style>body { margin: 0; font-family: sans-serif; }</style>
+  <!-- No resource hints: nothing unused to flag -->
+  <!-- No preloaded scripts: no anti-patterns -->
+</head>
+<body>
+  <!-- Above-fold hero: correct fetchpriority, no lazy -->
+  <img src="/hero.gif" width="300" height="200" alt="hero" fetchpriority="high">
+
+  <!-- Below-fold images: all properly lazy-loaded -->
+  <div style="margin-top: 2000px;">
+    <img src="/below1.gif" loading="lazy" width="100" height="100" alt="below fold 1">
+    <img src="/below2.gif" loading="lazy" width="100" height="100" alt="below fold 2">
+  </div>
+</body>
+</html>

--- a/cli/tests/fixtures/audit-violations.html
+++ b/cli/tests/fixtures/audit-violations.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Audit Violations — Deliberate Issues</title>
+  <!-- VIOLATION render-blocking: external CSS in <head> without preload -->
+  <link rel="stylesheet" href="/blocking.css">
+</head>
+<body>
+  <!-- VIOLATION lazy-atf: lazy image above the fold -->
+  <img src="/lazy-atf.gif" loading="lazy" width="300" height="200" alt="lazy above fold">
+
+  <!-- VIOLATION lazy-conflict: lazy + fetchpriority=high on the same element -->
+  <img src="/conflict.gif" loading="lazy" fetchpriority="high" width="200" height="150" alt="lazy conflict">
+
+  <!-- VIOLATION eager-below-fold: images below viewport without lazy loading -->
+  <!-- min 100x100 so the snippet does not exclude them as tracking pixels (<50px) -->
+  <div style="margin-top: 2000px;">
+    <img src="/eager1.gif" width="100" height="100" alt="eager below fold 1">
+    <img src="/eager2.gif" width="100" height="100" alt="eager below fold 2">
+  </div>
+</body>
+</html>

--- a/cli/tests/fixtures/index.html
+++ b/cli/tests/fixtures/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WebPerf Test Fixture</title>
+  <style>
+    body { margin: 0; font-family: sans-serif; padding: 20px; }
+  </style>
+</head>
+<body>
+  <h1 id="main-heading">WebPerf Snippets Test Page</h1>
+  <p>A minimal page for testing performance snippets.</p>
+</body>
+</html>

--- a/cli/tests/unit/decision-tree.test.js
+++ b/cli/tests/unit/decision-tree.test.js
@@ -7,21 +7,21 @@ describe("nextSteps", () => {
     expect(nextSteps(results)).toEqual([]);
   });
 
-  it("appends LCP-Sub-Parts when LCP > 2500ms", () => {
+  it("appends LCP-Subparts when LCP > 2500ms", () => {
     const results = [{ id: "LCP", status: "ok", value: 3000 }];
     const steps = nextSteps(results);
     expect(steps).toHaveLength(1);
-    expect(steps[0].id).toBe("LCP-Sub-Parts");
-    expect(steps[0].path).toBe("CoreWebVitals/LCP-Sub-Parts");
+    expect(steps[0].id).toBe("LCP-Subparts");
+    expect(steps[0].path).toBe("CoreWebVitals/LCP-Subparts");
     expect(steps[0].reason).toMatch(/LCP > 2\.5s/);
   });
 
-  it("does not append LCP-Sub-Parts when LCP === 2500ms (boundary)", () => {
+  it("does not append LCP-Subparts when LCP === 2500ms (boundary)", () => {
     const results = [{ id: "LCP", status: "ok", value: 2500 }];
     expect(nextSteps(results)).toEqual([]);
   });
 
-  it("does not append LCP-Sub-Parts when LCP status is error", () => {
+  it("does not append LCP-Subparts when LCP status is error", () => {
     const results = [{ id: "LCP", status: "error", value: 3000 }];
     expect(nextSteps(results)).toEqual([]);
   });

--- a/cli/tests/unit/decision-tree.test.js
+++ b/cli/tests/unit/decision-tree.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { nextSteps } from "../../src/decision-tree.js";
+
+describe("nextSteps", () => {
+  it("returns empty array when no rules match", () => {
+    const results = [{ id: "LCP", status: "ok", value: 1200 }];
+    expect(nextSteps(results)).toEqual([]);
+  });
+
+  it("appends LCP-Sub-Parts when LCP > 2500ms", () => {
+    const results = [{ id: "LCP", status: "ok", value: 3000 }];
+    const steps = nextSteps(results);
+    expect(steps).toHaveLength(1);
+    expect(steps[0].id).toBe("LCP-Sub-Parts");
+    expect(steps[0].path).toBe("CoreWebVitals/LCP-Sub-Parts");
+    expect(steps[0].reason).toMatch(/LCP > 2\.5s/);
+  });
+
+  it("does not append LCP-Sub-Parts when LCP === 2500ms (boundary)", () => {
+    const results = [{ id: "LCP", status: "ok", value: 2500 }];
+    expect(nextSteps(results)).toEqual([]);
+  });
+
+  it("does not append LCP-Sub-Parts when LCP status is error", () => {
+    const results = [{ id: "LCP", status: "error", value: 3000 }];
+    expect(nextSteps(results)).toEqual([]);
+  });
+
+  it("handles empty results", () => {
+    expect(nextSteps([])).toEqual([]);
+  });
+});

--- a/cli/tests/unit/reporters.test.js
+++ b/cli/tests/unit/reporters.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { reportJson } from "../../src/reporters/json.js";
+import { reportHuman } from "../../src/reporters/human.js";
+
+const samplePayload = {
+  url: "https://example.com",
+  navMs: 850,
+  results: [
+    { id: "LCP", status: "ok", metric: "LCP", value: 1200, unit: "ms", rating: "good" },
+    { id: "CLS", status: "ok", metric: "CLS", value: 0, unit: "score", rating: "good" },
+  ],
+  pageErrors: [],
+};
+
+describe("reportJson", () => {
+  it("returns valid JSON", () => {
+    const output = reportJson(samplePayload);
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("includes url, navMs, and results", () => {
+    const parsed = JSON.parse(reportJson(samplePayload));
+    expect(parsed.url).toBe("https://example.com");
+    expect(parsed.navMs).toBe(850);
+    expect(parsed.results).toHaveLength(2);
+  });
+
+  it("preserves result fields", () => {
+    const parsed = JSON.parse(reportJson(samplePayload));
+    expect(parsed.results[0]).toMatchObject({
+      id: "LCP",
+      status: "ok",
+      metric: "LCP",
+      value: 1200,
+      unit: "ms",
+      rating: "good",
+    });
+  });
+});
+
+describe("reportHuman", () => {
+  it("includes the URL in the output", () => {
+    const output = reportHuman(samplePayload);
+    expect(output).toContain("https://example.com");
+  });
+
+  it("includes metric IDs", () => {
+    const output = reportHuman(samplePayload);
+    expect(output).toContain("LCP");
+    expect(output).toContain("CLS");
+  });
+
+  it("reports error results", () => {
+    const payload = {
+      ...samplePayload,
+      results: [{ id: "LCP", status: "error", error: "No LCP entries buffered" }],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("No LCP entries buffered");
+  });
+
+  it("reports page errors section when present", () => {
+    const payload = { ...samplePayload, pageErrors: ["TypeError: x is not defined"] };
+    const output = reportHuman(payload);
+    expect(output).toContain("TypeError: x is not defined");
+  });
+});

--- a/cli/tests/unit/reporters.test.js
+++ b/cli/tests/unit/reporters.test.js
@@ -3,7 +3,7 @@ import { reportJson } from "../../src/reporters/json.js";
 import { reportHuman } from "../../src/reporters/human.js";
 
 const samplePayload = {
-  url: "https://example.com",
+  url: "https://web.dev",
   navMs: 850,
   results: [
     { id: "LCP", status: "ok", metric: "LCP", value: 1200, unit: "ms", rating: "good" },
@@ -20,7 +20,7 @@ describe("reportJson", () => {
 
   it("includes url, navMs, and results", () => {
     const parsed = JSON.parse(reportJson(samplePayload));
-    expect(parsed.url).toBe("https://example.com");
+    expect(parsed.url).toBe("https://web.dev");
     expect(parsed.navMs).toBe(850);
     expect(parsed.results).toHaveLength(2);
   });
@@ -41,7 +41,7 @@ describe("reportJson", () => {
 describe("reportHuman", () => {
   it("includes the URL in the output", () => {
     const output = reportHuman(samplePayload);
-    expect(output).toContain("https://example.com");
+    expect(output).toContain("https://web.dev");
   });
 
   it("includes metric IDs", () => {
@@ -67,7 +67,7 @@ describe("reportHuman", () => {
 
   it("renders fonts snippet result with counts and issues", () => {
     const payload = {
-      url: "https://example.com",
+      url: "https://web.dev",
       navMs: 500,
       results: [
         {
@@ -90,7 +90,7 @@ describe("reportHuman", () => {
 
   it("renders fonts snippet result with no issues as optimized", () => {
     const payload = {
-      url: "https://example.com",
+      url: "https://web.dev",
       navMs: 500,
       results: [
         {
@@ -111,7 +111,7 @@ describe("reportHuman", () => {
 
   it("renders audit result with no issues as passing", () => {
     const payload = {
-      url: "https://example.com",
+      url: "https://web.dev",
       navMs: 500,
       results: [
         {
@@ -133,7 +133,7 @@ describe("reportHuman", () => {
 
   it("renders audit result with error issues showing the message", () => {
     const payload = {
-      url: "https://example.com",
+      url: "https://web.dev",
       navMs: 500,
       results: [
         {
@@ -154,7 +154,7 @@ describe("reportHuman", () => {
 
   it("renders audit result with warning issues", () => {
     const payload = {
-      url: "https://example.com",
+      url: "https://web.dev",
       navMs: 500,
       results: [
         {

--- a/cli/tests/unit/reporters.test.js
+++ b/cli/tests/unit/reporters.test.js
@@ -64,4 +64,46 @@ describe("reportHuman", () => {
     const output = reportHuman(payload);
     expect(output).toContain("TypeError: x is not defined");
   });
+
+  it("renders fonts snippet result with counts and issues", () => {
+    const payload = {
+      url: "https://example.com",
+      navMs: 500,
+      results: [
+        {
+          id: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
+          status: "ok",
+          count: 2,
+          details: { preloadedCount: 1, loadedCount: 2, usedAboveFoldCount: 2, preloadedNotUsedCount: 1, usedNotPreloadedCount: 0 },
+          items: [],
+          issues: [{ severity: "warning", message: "Preloaded but not used above fold: font.woff2" }],
+        },
+      ],
+      pageErrors: [],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("preloaded: 1");
+    expect(output).toContain("loaded: 2");
+    expect(output).toContain("Preloaded but not used above fold: font.woff2");
+  });
+
+  it("renders fonts snippet result with no issues as optimized", () => {
+    const payload = {
+      url: "https://example.com",
+      navMs: 500,
+      results: [
+        {
+          id: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
+          status: "ok",
+          count: 1,
+          details: { preloadedCount: 1, loadedCount: 1, usedAboveFoldCount: 1, preloadedNotUsedCount: 0, usedNotPreloadedCount: 0 },
+          items: [],
+          issues: [],
+        },
+      ],
+      pageErrors: [],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("Font loading looks optimized");
+  });
 });

--- a/cli/tests/unit/reporters.test.js
+++ b/cli/tests/unit/reporters.test.js
@@ -71,7 +71,8 @@ describe("reportHuman", () => {
       navMs: 500,
       results: [
         {
-          id: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
+          id: "fonts",
+          script: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
           status: "ok",
           count: 2,
           details: { preloadedCount: 1, loadedCount: 2, usedAboveFoldCount: 2, preloadedNotUsedCount: 1, usedNotPreloadedCount: 0 },
@@ -94,6 +95,7 @@ describe("reportHuman", () => {
       results: [
         {
           id: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
+          script: "Fonts-Preloaded-Loaded-and-used-above-the-fold",
           status: "ok",
           count: 1,
           details: { preloadedCount: 1, loadedCount: 1, usedAboveFoldCount: 1, preloadedNotUsedCount: 0, usedNotPreloadedCount: 0 },
@@ -105,5 +107,69 @@ describe("reportHuman", () => {
     };
     const output = reportHuman(payload);
     expect(output).toContain("Font loading looks optimized");
+  });
+
+  it("renders audit result with no issues as passing", () => {
+    const payload = {
+      url: "https://example.com",
+      navMs: 500,
+      results: [
+        {
+          id: "render-blocking",
+          script: "Find-render-blocking-resources",
+          status: "ok",
+          count: 0,
+          details: { totalBlockingUntilMs: 0, totalSizeBytes: 0, byType: {} },
+          items: [],
+          issues: [],
+        },
+      ],
+      pageErrors: [],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("render-blocking");
+    expect(output).toContain("No issues");
+  });
+
+  it("renders audit result with error issues showing the message", () => {
+    const payload = {
+      url: "https://example.com",
+      navMs: 500,
+      results: [
+        {
+          id: "lazy-conflict",
+          script: "Find-Images-With-Lazy-and-Fetchpriority",
+          status: "ok",
+          count: 2,
+          items: [],
+          issues: [{ severity: "error", message: "2 element(s) have conflicting loading=\"lazy\" and fetchpriority=\"high\"" }],
+        },
+      ],
+      pageErrors: [],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("lazy-conflict");
+    expect(output).toContain("2 element(s) have conflicting");
+  });
+
+  it("renders audit result with warning issues", () => {
+    const payload = {
+      url: "https://example.com",
+      navMs: 500,
+      results: [
+        {
+          id: "eager-below-fold",
+          script: "Find-non-Lazy-Loaded-Images-outside-of-the-viewport",
+          status: "ok",
+          count: 5,
+          items: [],
+          issues: [{ severity: "warning", message: "5 image(s) outside the viewport are missing loading=\"lazy\"" }],
+        },
+      ],
+      pageErrors: [],
+    };
+    const output = reportHuman(payload);
+    expect(output).toContain("eager-below-fold");
+    expect(output).toContain("5 image(s) outside the viewport");
   });
 });

--- a/cli/tests/unit/viewport-presets.test.js
+++ b/cli/tests/unit/viewport-presets.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { VIEWPORT_PRESETS } from "../../src/runner.js";
+
+describe("VIEWPORT_PRESETS", () => {
+  it("defines mobile, tablet, and desktop presets", () => {
+    expect(VIEWPORT_PRESETS).toHaveProperty("mobile");
+    expect(VIEWPORT_PRESETS).toHaveProperty("tablet");
+    expect(VIEWPORT_PRESETS).toHaveProperty("desktop");
+  });
+
+  it("mobile is the narrowest preset", () => {
+    expect(VIEWPORT_PRESETS.mobile.width).toBeLessThan(VIEWPORT_PRESETS.tablet.width);
+    expect(VIEWPORT_PRESETS.tablet.width).toBeLessThan(VIEWPORT_PRESETS.desktop.width);
+  });
+
+  it("mobile width matches a phone form factor", () => {
+    expect(VIEWPORT_PRESETS.mobile.width).toBe(375);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "webperf-snippets",
+  "name": "webperf-snippets-docs",
   "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "webperf-snippets",
+      "name": "webperf-snippets-docs",
       "version": "1.2.0",
       "license": "MIT",
+      "workspaces": [
+        "cli"
+      ],
       "dependencies": {
         "next": "^13.4.19",
         "next-cloudinary": "^4.18.0",
@@ -21,6 +24,25 @@
         "eslint": "^10.0.2",
         "terser": "^5.36.0",
         "vercel": "^32.4.1"
+      }
+    },
+    "cli": {
+      "name": "webperf-snippets",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "webperf-snippets": "src/bin.js"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      },
+      "peerDependencies": {
+        "playwright": ">=1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": false
+        }
       }
     },
     "node_modules/@actions/core": {
@@ -14067,6 +14089,53 @@
         "node": ">=4"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -20278,6 +20347,10 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/webperf-snippets": {
+      "resolved": "cli",
+      "link": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,9 @@
       "bin": {
         "webperf-snippets": "src/bin.js"
       },
+      "devDependencies": {
+        "vitest": "^2.0.0"
+      },
       "engines": {
         "node": ">=20.12.0"
       },
@@ -42,6 +45,242 @@
       "peerDependenciesMeta": {
         "playwright": {
           "optional": false
+        }
+      }
+    },
+    "cli/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "cli/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "cli/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "cli/node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "cli/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "cli/node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
         }
       }
     },
@@ -266,6 +505,397 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1477,6 +2107,356 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -2611,6 +3591,92 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -2855,6 +3921,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -2991,6 +4067,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3029,6 +4115,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3092,6 +4195,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -4282,6 +5395,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -4776,6 +5899,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esast-util-from-estree": {
       "version": "2.0.0",
@@ -5682,6 +6812,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -8174,12 +9314,29 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-asynchronous": {
       "version": "1.0.1",
@@ -14029,6 +15186,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -15908,6 +17082,66 @@
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
       "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -18733,6 +19967,13 @@
         "vscode-textmate": "^8.0.0"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -18986,6 +20227,13 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
@@ -19002,6 +20250,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",
@@ -19439,6 +20694,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -19485,6 +20754,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/title": {
@@ -20293,6 +21592,172 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite-node/node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
@@ -20376,6 +21841,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
-  "name": "webperf-snippets",
+  "name": "webperf-snippets-docs",
   "private": true,
   "version": "1.2.0",
-  "description": "Web Performance Snippets",
+  "description": "Web Performance Snippets — documentation site",
+  "workspaces": [
+    "cli"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pages/CLI.mdx
+++ b/pages/CLI.mdx
@@ -6,6 +6,21 @@ type: guide
 
 Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes and gate CI on real performance budgets.
 
+<picture style={{ marginTop: "20px", display: "block" }}>
+  <img
+    width="1200"
+    height="749"
+    sizes="85vw"
+    srcSet="https://res.cloudinary.com/nucliweb/image/upload/c_scale,f_auto,q_auto,w_600/v1777928598/webperf-snippets/webperf-snippets-CLI.png 600w,
+            https://res.cloudinary.com/nucliweb/image/upload/c_scale,f_auto,q_auto,w_1200/v1777928598/webperf-snippets/webperf-snippets-CLI.png 1200w"
+    src="https://res.cloudinary.com/nucliweb/image/upload/c_scale,f_auto,q_auto,w_342/v1777928598/webperf-snippets/webperf-snippets-CLI.png"
+    loading="eager"
+    decoding="sync"
+    fetchpriority="high"
+    alt="WebPerf Snippets CLI"
+  />
+</picture>
+
 ## Why
 
 Lighthouse gives you a score. The DevTools snippets give you the _diagnosis_ — TTFB / Resource Load Delay / Element Render Delay sub-parts, LoAF script attribution, render-blocking resources, and more. The CLI runs the same curated snippets in a headless browser so you can:

--- a/pages/CLI.mdx
+++ b/pages/CLI.mdx
@@ -1,0 +1,105 @@
+# CLI
+
+Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes and gate CI on real performance budgets.
+
+## Why
+
+Lighthouse gives you a score. The DevTools snippets give you the _diagnosis_ — TTFB / Resource Load Delay / Element Render Delay sub-parts, LoAF script attribution, render-blocking resources, and more. The CLI runs the same curated snippets in a headless browser so you can:
+
+- Diagnose LCP regressions in CI without copy-pasting into DevTools.
+- Gate pull requests on real performance budgets.
+- Automate the snippets you already run by hand.
+
+## Install
+
+Playwright is a peer dependency. Install both, then download the Chromium browser:
+
+```bash copy
+npm install --save-dev webperf-snippets playwright
+npx playwright install chromium
+```
+
+## Usage
+
+```bash copy
+npx webperf-snippets <url> [options]
+```
+
+### Examples
+
+Run the default Core Web Vitals workflow (LCP + CLS, plus LCP-Subparts when LCP exceeds 2.5s):
+
+```bash copy
+npx webperf-snippets https://web.dev
+```
+
+JSON output (for piping into `jq` or CI scripts):
+
+```bash copy
+npx webperf-snippets https://web.dev --json
+```
+
+Run a single snippet:
+
+```bash copy
+npx webperf-snippets https://web.dev --snippet LCP-Subparts
+```
+
+Gate CI on performance budgets:
+
+```bash copy
+npx webperf-snippets https://web.dev --budget-lcp 2500 --budget-cls 0.1
+```
+
+### Options
+
+| Option                 | Description                                                 |
+| ---------------------- | ----------------------------------------------------------- |
+| `--workflow <name>`    | Workflow to run. Default: `core-web-vitals`.                |
+| `--snippet <name>`     | Run a single snippet (`LCP`, `CLS`, or `Category/Name`).    |
+| `--json`               | Output JSON instead of formatted text.                      |
+| `--wait <ms>`          | Post-load wait before evaluating snippets. Default: `3000`. |
+| `--budget-lcp <ms>`    | Exit `1` if LCP exceeds this value.                         |
+| `--budget-cls <score>` | Exit `1` if CLS exceeds this value.                         |
+| `--headed`             | Show the browser window (debug).                            |
+| `-h, --help`           | Show help.                                                  |
+
+### Exit codes
+
+| Code | Meaning                                      |
+| ---- | -------------------------------------------- |
+| `0`  | All checks passed.                           |
+| `1`  | Budget violation, or a snippet errored.      |
+| `2`  | Usage error (missing URL, unknown workflow). |
+
+## CI Integration
+
+GitHub Actions example — fail the PR if LCP exceeds 2.5s:
+
+```yaml copy
+- run: |
+    npm install --no-save webperf-snippets playwright
+    npx playwright install --with-deps chromium
+    npx webperf-snippets https://staging.web.dev --budget-lcp 2500 --budget-cls 0.1
+```
+
+## How it works
+
+1. Launches headless Chromium via Playwright.
+2. Pre-registers `PerformanceObserver`s for LCP and layout-shift before navigation.
+3. Navigates and waits for the page to settle.
+4. Evaluates each snippet's IIFE in the page context, capturing the returned object.
+5. Applies the workflow's decision tree to enqueue follow-up snippets.
+6. Renders results (human-readable or JSON) and exits with the appropriate code.
+
+## Known limitations
+
+- **No INP**: INP requires real user interactions. Synthetic interaction support is planned.
+- **CLS in headless is conservative**: layout shifts that only happen on scroll are missed unless you script the scroll.
+- **First navigation only**: each invocation runs one URL. SPAs need the post-route URL passed directly.
+- **Decision-tree follow-ups re-navigate**: when a follow-up snippet fires (e.g. LCP-Subparts), the page reloads. A shared page session is planned.
+
+## Further reading
+
+- [GitHub Repository](https://github.com/nucliweb/webperf-snippets) — source code and issue tracker
+- [npm package](https://www.npmjs.com/package/webperf-snippets) — changelog and releases

--- a/pages/CLI.mdx
+++ b/pages/CLI.mdx
@@ -43,11 +43,33 @@ JSON output (for piping into `jq` or CI scripts):
 npx webperf-snippets https://web.dev --json
 ```
 
-Run a single snippet:
+Run a single snippet by alias:
 
 ```bash copy
 npx webperf-snippets https://web.dev --snippet LCP-Subparts
+npx webperf-snippets https://web.dev --snippet render-blocking
+npx webperf-snippets https://web.dev --snippet fonts
 ```
+
+### Snippet aliases
+
+| Alias | Snippet | Category |
+| ----- | ------- | -------- |
+| `LCP` | Largest Contentful Paint | Core Web Vitals |
+| `CLS` | Cumulative Layout Shift | Core Web Vitals |
+| `LCP-Subparts` | LCP Subparts breakdown | Core Web Vitals |
+| `fonts` | Fonts Preloaded, Loaded, and Used Above The Fold | Loading |
+| `render-blocking` | Find render-blocking resources | Loading |
+| `resource-hints` | Resource Hints Validation | Loading |
+| `preload-scripts` | Validate Preload / Async / Defer Scripts | Loading |
+| `priority-hints` | Priority Hints Audit | Loading |
+| `critical-css` | Critical CSS Detection | Loading |
+| `ttfb` | TTFB Sub-Parts | Loading |
+| `script-parties` | First and Third-Party Script Info | Loading |
+| `script-loading` | Script Loading | Loading |
+| `lazy-atf` | Above-the-fold lazy-loaded images | Loading |
+| `lazy-conflict` | Images with `lazy` + `fetchpriority` conflict | Loading |
+| `eager-below-fold` | Non-lazy images outside viewport | Loading |
 
 Gate CI on performance budgets:
 
@@ -55,18 +77,39 @@ Gate CI on performance budgets:
 npx webperf-snippets https://web.dev --budget-lcp 2500 --budget-cls 0.1
 ```
 
+Run the structural audit workflow:
+
+```bash copy
+npx webperf-snippets https://web.dev --workflow audit
+```
+
+Simulate a mobile viewport (default) or switch to desktop:
+
+```bash copy
+npx webperf-snippets https://web.dev --viewport mobile
+npx webperf-snippets https://web.dev --viewport desktop
+```
+
+Show all items, including passing checks:
+
+```bash copy
+npx webperf-snippets https://web.dev --verbose
+```
+
 ### Options
 
-| Option                 | Description                                                 |
-| ---------------------- | ----------------------------------------------------------- |
-| `--workflow <name>`    | Workflow to run. Default: `core-web-vitals`.                |
-| `--snippet <name>`     | Run a single snippet (`LCP`, `CLS`, or `Category/Name`).    |
-| `--json`               | Output JSON instead of formatted text.                      |
-| `--wait <ms>`          | Post-load wait before evaluating snippets. Default: `3000`. |
-| `--budget-lcp <ms>`    | Exit `1` if LCP exceeds this value.                         |
-| `--budget-cls <score>` | Exit `1` if CLS exceeds this value.                         |
-| `--headed`             | Show the browser window (debug).                            |
-| `-h, --help`           | Show help.                                                  |
+| Option                  | Description                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `--workflow <name>`     | Workflow to run. Default: `core-web-vitals`. Options: `core-web-vitals`, `audit`.    |
+| `--snippet <name>`      | Run a single snippet by alias or `Category/Name` path.                               |
+| `--json`                | Output JSON instead of formatted text.                                               |
+| `--viewport <preset>`   | Viewport preset. Default: `mobile`. Options: `mobile`, `tablet`, `desktop`.          |
+| `--wait <ms>`           | Post-load wait before evaluating snippets. Default: `3000`.                          |
+| `--budget-lcp <ms>`     | Exit `1` if LCP exceeds this value.                                                  |
+| `--budget-cls <score>`  | Exit `1` if CLS exceeds this value.                                                  |
+| `--verbose`             | Show all items, including passing checks.                                            |
+| `--headed`              | Show the browser window (debug).                                                     |
+| `-h, --help`            | Show help.                                                                           |
 
 ### Exit codes
 

--- a/pages/CLI.mdx
+++ b/pages/CLI.mdx
@@ -1,3 +1,7 @@
+---
+type: guide
+---
+
 # CLI
 
 Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes and gate CI on real performance budgets.

--- a/pages/CLI.mdx
+++ b/pages/CLI.mdx
@@ -2,7 +2,7 @@
 type: guide
 ---
 
-# CLI
+# WebPerf Snippets CLI
 
 Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals beyond what Lighthouse exposes and gate CI on real performance budgets.
 
@@ -23,7 +23,7 @@ Run curated WebPerf Snippets headlessly via Playwright. Diagnose Core Web Vitals
 
 ## Why
 
-Lighthouse gives you a score. The DevTools snippets give you the _diagnosis_ — TTFB / Resource Load Delay / Element Render Delay sub-parts, LoAF script attribution, render-blocking resources, and more. The CLI runs the same curated snippets in a headless browser so you can:
+Lighthouse gives you a score. The DevTools snippets give you the _diagnosis_, TTFB / Resource Load Delay / Element Render Delay sub-parts, LoAF script attribution, render-blocking resources, and more. The CLI runs the same curated snippets in a headless browser so you can:
 
 - Diagnose LCP regressions in CI without copy-pasting into DevTools.
 - Gate pull requests on real performance budgets.
@@ -68,23 +68,23 @@ npx webperf-snippets https://web.dev --snippet fonts
 
 ### Snippet aliases
 
-| Alias | Snippet | Category |
-| ----- | ------- | -------- |
-| `LCP` | Largest Contentful Paint | Core Web Vitals |
-| `CLS` | Cumulative Layout Shift | Core Web Vitals |
-| `LCP-Subparts` | LCP Subparts breakdown | Core Web Vitals |
-| `fonts` | Fonts Preloaded, Loaded, and Used Above The Fold | Loading |
-| `render-blocking` | Find render-blocking resources | Loading |
-| `resource-hints` | Resource Hints Validation | Loading |
-| `preload-scripts` | Validate Preload / Async / Defer Scripts | Loading |
-| `priority-hints` | Priority Hints Audit | Loading |
-| `critical-css` | Critical CSS Detection | Loading |
-| `ttfb` | TTFB Sub-Parts | Loading |
-| `script-parties` | First and Third-Party Script Info | Loading |
-| `script-loading` | Script Loading | Loading |
-| `lazy-atf` | Above-the-fold lazy-loaded images | Loading |
-| `lazy-conflict` | Images with `lazy` + `fetchpriority` conflict | Loading |
-| `eager-below-fold` | Non-lazy images outside viewport | Loading |
+| Alias              | Snippet                                          | Category        |
+| ------------------ | ------------------------------------------------ | --------------- |
+| `LCP`              | Largest Contentful Paint                         | Core Web Vitals |
+| `CLS`              | Cumulative Layout Shift                          | Core Web Vitals |
+| `LCP-Subparts`     | LCP Subparts breakdown                           | Core Web Vitals |
+| `fonts`            | Fonts Preloaded, Loaded, and Used Above The Fold | Loading         |
+| `render-blocking`  | Find render-blocking resources                   | Loading         |
+| `resource-hints`   | Resource Hints Validation                        | Loading         |
+| `preload-scripts`  | Validate Preload / Async / Defer Scripts         | Loading         |
+| `priority-hints`   | Priority Hints Audit                             | Loading         |
+| `critical-css`     | Critical CSS Detection                           | Loading         |
+| `ttfb`             | TTFB Sub-Parts                                   | Loading         |
+| `script-parties`   | First and Third-Party Script Info                | Loading         |
+| `script-loading`   | Script Loading                                   | Loading         |
+| `lazy-atf`         | Above-the-fold lazy-loaded images                | Loading         |
+| `lazy-conflict`    | Images with `lazy` + `fetchpriority` conflict    | Loading         |
+| `eager-below-fold` | Non-lazy images outside viewport                 | Loading         |
 
 Gate CI on performance budgets:
 
@@ -113,18 +113,18 @@ npx webperf-snippets https://web.dev --verbose
 
 ### Options
 
-| Option                  | Description                                                                          |
-| ----------------------- | ------------------------------------------------------------------------------------ |
-| `--workflow <name>`     | Workflow to run. Default: `core-web-vitals`. Options: `core-web-vitals`, `audit`.    |
-| `--snippet <name>`      | Run a single snippet by alias or `Category/Name` path.                               |
-| `--json`                | Output JSON instead of formatted text.                                               |
-| `--viewport <preset>`   | Viewport preset. Default: `mobile`. Options: `mobile`, `tablet`, `desktop`.          |
-| `--wait <ms>`           | Post-load wait before evaluating snippets. Default: `3000`.                          |
-| `--budget-lcp <ms>`     | Exit `1` if LCP exceeds this value.                                                  |
-| `--budget-cls <score>`  | Exit `1` if CLS exceeds this value.                                                  |
-| `--verbose`             | Show all items, including passing checks.                                            |
-| `--headed`              | Show the browser window (debug).                                                     |
-| `-h, --help`            | Show help.                                                                           |
+| Option                 | Description                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| `--workflow <name>`    | Workflow to run. Default: `core-web-vitals`. Options: `core-web-vitals`, `audit`. |
+| `--snippet <name>`     | Run a single snippet by alias or `Category/Name` path.                            |
+| `--json`               | Output JSON instead of formatted text.                                            |
+| `--viewport <preset>`  | Viewport preset. Default: `mobile`. Options: `mobile`, `tablet`, `desktop`.       |
+| `--wait <ms>`          | Post-load wait before evaluating snippets. Default: `3000`.                       |
+| `--budget-lcp <ms>`    | Exit `1` if LCP exceeds this value.                                               |
+| `--budget-cls <score>` | Exit `1` if CLS exceeds this value.                                               |
+| `--verbose`            | Show all items, including passing checks.                                         |
+| `--headed`             | Show the browser window (debug).                                                  |
+| `-h, --help`           | Show help.                                                                        |
 
 ### Exit codes
 
@@ -136,7 +136,7 @@ npx webperf-snippets https://web.dev --verbose
 
 ## CI Integration
 
-GitHub Actions example — fail the PR if LCP exceeds 2.5s:
+GitHub Actions example, fail the PR if LCP exceeds 2.5s:
 
 ```yaml copy
 - run: |
@@ -163,5 +163,5 @@ GitHub Actions example — fail the PR if LCP exceeds 2.5s:
 
 ## Further reading
 
-- [GitHub Repository](https://github.com/nucliweb/webperf-snippets) — source code and issue tracker
-- [npm package](https://www.npmjs.com/package/webperf-snippets) — changelog and releases
+- [GitHub Repository](https://github.com/nucliweb/webperf-snippets), source code and issue tracker
+- [npm package](https://www.npmjs.com/package/webperf-snippets), changelog and releases

--- a/pages/Loading/Back-Forward-Cache.mdx
+++ b/pages/Loading/Back-Forward-Cache.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/Back-Forward-Cache.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/Back-Forward-Cache.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # Back/Forward Cache (bfcache)
 
@@ -13,10 +13,10 @@ bfcache is one of the most impactful performance optimizations available - it ca
 
 **bfcache Impact:**
 
-| Navigation Type | Load Time | User Experience |
-|----------------|-----------|-----------------|
-| Normal navigation | 1-3s | Wait, spinner |
-| bfcache restoration | 0ms | Instant |
+| Navigation Type     | Load Time | User Experience |
+| ------------------- | --------- | --------------- |
+| Normal navigation   | 1-3s      | Wait, spinner   |
+| bfcache restoration | 0ms       | Instant         |
 
 **How bfcache works:**
 
@@ -120,38 +120,40 @@ Page A → Page B → [Back] → Page A (full reload, 1-3s)
 
 ### Common Blockers and Solutions
 
-| Blocker | Why it blocks | Solution |
-|---------|--------------|----------|
-| **unload event** | Can't be reliably replayed | Use `pagehide` or `visibilitychange` |
-| **beforeunload** | Prevents navigation caching | Remove or use `pagehide` for cleanup |
-| **Cache-Control: no-store** | Tells browser not to cache | Change to `no-cache` or `private` |
-| **Open IndexedDB transaction** | State can't be serialized | Close transactions on `pagehide` |
-| **WebSocket connection** | Can't be suspended | Close on `pagehide`, reconnect on `pageshow` |
-| **Ongoing fetch/XHR** | Incomplete network state | Abort on `pagehide` |
-| **BroadcastChannel** | Can't be suspended | Close on `pagehide` |
+| Blocker                        | Why it blocks               | Solution                                     |
+| ------------------------------ | --------------------------- | -------------------------------------------- |
+| **unload event**               | Can't be reliably replayed  | Use `pagehide` or `visibilitychange`         |
+| **beforeunload**               | Prevents navigation caching | Remove or use `pagehide` for cleanup         |
+| **Cache-Control: no-store**    | Tells browser not to cache  | Change to `no-cache` or `private`            |
+| **Open IndexedDB transaction** | State can't be serialized   | Close transactions on `pagehide`             |
+| **WebSocket connection**       | Can't be suspended          | Close on `pagehide`, reconnect on `pageshow` |
+| **Ongoing fetch/XHR**          | Incomplete network state    | Abort on `pagehide`                          |
+| **BroadcastChannel**           | Can't be suspended          | Close on `pagehide`                          |
 
 ### Fixing Common Issues
 
 #### Issue 1: unload/beforeunload handlers
 
 **Bad:**
+
 ```javascript
-window.addEventListener('unload', () => {
+window.addEventListener("unload", () => {
   saveData(); // Blocks bfcache
 });
 
-window.addEventListener('beforeunload', () => {
-  return 'Are you sure?'; // Blocks bfcache
+window.addEventListener("beforeunload", () => {
+  return "Are you sure?"; // Blocks bfcache
 });
 ```
 
 **Good:**
+
 ```javascript
-window.addEventListener('pagehide', (event) => {
+window.addEventListener("pagehide", (event) => {
   // event.persisted tells you if page goes to bfcache
   if (event.persisted) {
     // Page will be cached, do minimal cleanup
-    console.log('Page going to bfcache');
+    console.log("Page going to bfcache");
   } else {
     // Page being discarded, do full cleanup
     saveData();
@@ -162,36 +164,40 @@ window.addEventListener('pagehide', (event) => {
 #### Issue 2: Cache-Control: no-store
 
 **Bad:**
+
 ```html
-<meta http-equiv="Cache-Control" content="no-store">
+<meta http-equiv="Cache-Control" content="no-store" />
 ```
 
 **Good:**
+
 ```html
 <!-- Remove the meta tag entirely, or use: -->
-<meta http-equiv="Cache-Control" content="no-cache">
+<meta http-equiv="Cache-Control" content="no-cache" />
 ```
 
 #### Issue 3: Open WebSocket
 
 **Bad:**
+
 ```javascript
-const ws = new WebSocket('wss://example.com');
+const ws = new WebSocket("wss://web.dev");
 // Connection stays open, blocks bfcache
 ```
 
 **Good:**
-```javascript
-const ws = new WebSocket('wss://example.com');
 
-window.addEventListener('pagehide', () => {
+```javascript
+const ws = new WebSocket("wss://web.dev");
+
+window.addEventListener("pagehide", () => {
   ws.close(); // Close on navigation
 });
 
-window.addEventListener('pageshow', (event) => {
+window.addEventListener("pageshow", (event) => {
   if (event.persisted) {
     // Reconnect after bfcache restore
-    ws = new WebSocket('wss://example.com');
+    ws = new WebSocket("wss://web.dev");
   }
 });
 ```
@@ -199,24 +205,26 @@ window.addEventListener('pageshow', (event) => {
 #### Issue 4: IndexedDB
 
 **Bad:**
+
 ```javascript
-const request = indexedDB.open('myDB');
+const request = indexedDB.open("myDB");
 request.onsuccess = () => {
   const db = request.result;
-  const transaction = db.transaction(['store'], 'readwrite');
+  const transaction = db.transaction(["store"], "readwrite");
   // Transaction stays open, blocks bfcache
 };
 ```
 
 **Good:**
+
 ```javascript
 let db;
-const request = indexedDB.open('myDB');
+const request = indexedDB.open("myDB");
 request.onsuccess = () => {
   db = request.result;
 };
 
-window.addEventListener('pagehide', () => {
+window.addEventListener("pagehide", () => {
   db?.close(); // Close connection
 });
 ```
@@ -228,21 +236,24 @@ window.addEventListener('pagehide', () => {
 ⚠️ **Important: Execution order matters!**
 
 **Correct order:**
+
 1. **First**: Open your page
 2. **Second**: Run this snippet (to register event listeners)
 3. **Third**: Navigate to another page (e.g., click a link)
 4. **Fourth**: Press browser Back button
 5. **Fifth**: Check console for results
 
-**Why this order?** The snippet needs to be listening for the `pageshow` event with `persisted: true` to detect bfcache restoration. If you run the snippet *after* clicking Back, you'll miss the restoration event.
+**Why this order?** The snippet needs to be listening for the `pageshow` event with `persisted: true` to detect bfcache restoration. If you run the snippet _after_ clicking Back, you'll miss the restoration event.
 
 **If you run the snippet after navigating back:**
+
 - ⚠️ You'll see a timing warning
 - ❌ Won't detect if page was restored from bfcache
 - ✅ Will still show `NotRestoredReasons` from that navigation
 - ✅ Will still analyze current eligibility
 
 **Output when run in correct order:**
+
 ```
 ⚡ Page restored from bfcache!
    Navigation was instant (0ms)
@@ -267,28 +278,28 @@ Chrome 123+ provides the detailed `notRestoredReasons` API that shows exactly wh
 **API structure:**
 
 ```javascript
-const navEntry = performance.getEntriesByType('navigation')[0];
+const navEntry = performance.getEntriesByType("navigation")[0];
 if (navEntry.notRestoredReasons) {
   const reasons = navEntry.notRestoredReasons;
 
   // Page-level information
-  console.log('Blocked:', reasons.blocked);        // boolean
-  console.log('URL:', reasons.url);                // page URL
-  console.log('Frame ID:', reasons.id);            // frame identifier
-  console.log('Name:', reasons.name);              // frame name (if any)
-  console.log('Source:', reasons.src);             // frame source (if iframe)
+  console.log("Blocked:", reasons.blocked); // boolean
+  console.log("URL:", reasons.url); // page URL
+  console.log("Frame ID:", reasons.id); // frame identifier
+  console.log("Name:", reasons.name); // frame name (if any)
+  console.log("Source:", reasons.src); // frame source (if iframe)
 
   // Array of NotRestoredReasonDetails objects
-  reasons.reasons.forEach(detail => {
-    console.log('Reason:', detail.reason);         // blocking reason
-    console.log('Source:', detail.source);         // where it came from
+  reasons.reasons.forEach((detail) => {
+    console.log("Reason:", detail.reason); // blocking reason
+    console.log("Source:", detail.source); // where it came from
   });
 
   // Nested iframes
-  reasons.children.forEach(child => {
-    console.log('Child URL:', child.url);
-    console.log('Child blocked:', child.blocked);
-    console.log('Child reasons:', child.reasons);
+  reasons.children.forEach((child) => {
+    console.log("Child URL:", child.url);
+    console.log("Child blocked:", child.blocked);
+    console.log("Child reasons:", child.reasons);
   });
 }
 ```
@@ -299,20 +310,20 @@ if (navEntry.notRestoredReasons) {
 
 Each blocking reason is a `NotRestoredReasonDetails` object with these properties:
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `reason` | string | The specific blocking reason (e.g., "WebSocket", "unload-listener") |
+| Property | Type   | Description                                                                |
+| -------- | ------ | -------------------------------------------------------------------------- |
+| `reason` | string | The specific blocking reason (e.g., "WebSocket", "unload-listener")        |
 | `source` | string | Source location: "UserAgentOnly" (browser), "JavaScript" (your code), etc. |
 
 **Common reason values:**
 
-| Reason | What it means |
-|--------|---------------|
-| `unload-listener` | Page has unload event listener |
-| `response-cache-control` | Cache-Control: no-store header |
-| `WebSocket` | Open WebSocket connection |
-| `IndexedDB` | Open IndexedDB transaction |
-| `BroadcastChannel` | Open BroadcastChannel |
+| Reason                    | What it means                              |
+| ------------------------- | ------------------------------------------ |
+| `unload-listener`         | Page has unload event listener             |
+| `response-cache-control`  | Cache-Control: no-store header             |
+| `WebSocket`               | Open WebSocket connection                  |
+| `IndexedDB`               | Open IndexedDB transaction                 |
+| `BroadcastChannel`        | Open BroadcastChannel                      |
 | `related-active-contents` | Related page (popup/iframe) blocks caching |
 
 **Example output interpretation:**
@@ -332,6 +343,7 @@ Each blocking reason is a `NotRestoredReasonDetails` object with these propertie
 ```
 
 This tells us:
+
 - ✅ Page was **not blocked** this time (blocked: false)
 - ❌ But a **WebSocket** connection was detected
 - 📍 It came from **JavaScript** code (not browser extension)
@@ -340,14 +352,17 @@ This tells us:
 ### Interpreting Your Results
 
 **Scenario 1: Fast back/forward (< 10ms)**
+
 ```
 Type: back_forward
 Duration: 8ms
 ✅ Page restored from bfcache
 ```
+
 ✅ **Excellent!** bfcache is working perfectly.
 
 **Scenario 2: Slow back/forward (> 100ms) with reasons**
+
 ```
 Type: back_forward
 Duration: 405ms
@@ -357,14 +372,17 @@ Blocking reasons:
 - WebSocket connection detected
 - Source: JavaScript
 ```
+
 ❌ **Action needed:** Your page has blockers preventing bfcache. Fix the listed issues.
 
 **Scenario 3: Blocked = false, but slow navigation**
+
 ```
 blocked: false
 Duration: 405ms
 Reasons: [WebSocket]
 ```
+
 ⚠️ **Important:** Even though `blocked: false`, the page wasn't cached on the **previous** navigation because of WebSocket. Fix it and test again with a fresh navigation cycle.
 
 ### Testing Workflow
@@ -386,6 +404,7 @@ To get accurate `notRestoredReasons` data:
    - Run the snippet after clicking back to see results
 
 **Chrome DevTools shortcut:**
+
 - DevTools → Application → Back/forward cache
 - Click "Test back/forward cache" button
 - Instantly see detailed blocking reasons
@@ -395,6 +414,7 @@ To get accurate `notRestoredReasons` data:
 The snippet displays detailed information about `NotRestoredReasonDetails` objects:
 
 **Blocking reasons format:**
+
 ```
 Blocking reasons:
 1. WebSocket
@@ -411,6 +431,7 @@ Blocking reasons:
 ```
 
 Each blocking reason shows:
+
 - **Reason**: The specific blocker (e.g., "WebSocket", "unload-listener")
 - **Source**: Where it comes from ("JavaScript", "UserAgentOnly")
 - **Context**: Helpful explanation and recommended fix
@@ -418,12 +439,12 @@ Each blocking reason shows:
 
 ### Browser Support
 
-| Browser | bfcache Support | NotRestoredReasons API |
-|---------|-----------------|------------------------|
-| Chrome 96+ | ✅ | ✅ (123+) |
-| Edge 96+ | ✅ | ✅ (123+) |
-| Safari 14+ | ✅ | ❌ |
-| Firefox 86+ | ✅ | ❌ |
+| Browser     | bfcache Support | NotRestoredReasons API |
+| ----------- | --------------- | ---------------------- |
+| Chrome 96+  | ✅              | ✅ (123+)              |
+| Edge 96+    | ✅              | ✅ (123+)              |
+| Safari 14+  | ✅              | ❌                     |
+| Firefox 86+ | ✅              | ❌                     |
 
 All modern browsers support bfcache, but diagnostics vary.
 
@@ -434,6 +455,7 @@ All modern browsers support bfcache, but diagnostics vary.
 **Real example from joanleon.dev when executed incorrectly:**
 
 **What happened:**
+
 1. User visited https://joanleon.dev/
 2. Clicked on a blog post
 3. Clicked browser Back button ← Navigation already happened
@@ -478,12 +500,14 @@ For complete analysis including bfcache restoration detection:
 ```
 
 **Why this output is incomplete:**
+
 - ❌ Missed the `pageshow` event with `persisted=true`
 - ❌ Cannot confirm if page was actually restored from bfcache
 - ✅ Still shows `NotRestoredReasons` (helpful for diagnosis)
 - ✅ Still shows current eligibility analysis
 
 **Diagnosis from available data:**
+
 1. ✅ **Good news**: No unload handlers, no Cache-Control issues
 2. ❌ **Problem**: WebSocket connection blocking bfcache
 3. 📊 **Impact**: 405ms reload vs. potential 0ms with bfcache
@@ -496,6 +520,7 @@ For complete analysis including bfcache restoration detection:
 **Correct workflow for joanleon.dev:**
 
 **What to do:**
+
 1. Visit https://joanleon.dev/
 2. **First**: Run the snippet ← Sets up event listeners
 3. Click on a blog post
@@ -535,20 +560,20 @@ For complete analysis including bfcache restoration detection:
 **Fix applied:**
 
 ```javascript
-let ws = new WebSocket('wss://example.com/updates');
+let ws = new WebSocket("wss://web.dev/updates");
 
 // Close connection when leaving page
-window.addEventListener('pagehide', () => {
+window.addEventListener("pagehide", () => {
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.close();
   }
 });
 
 // Reconnect after bfcache restore
-window.addEventListener('pageshow', (event) => {
+window.addEventListener("pageshow", (event) => {
   if (event.persisted) {
     // Page restored from bfcache, reconnect
-    ws = new WebSocket('wss://example.com/updates');
+    ws = new WebSocket("wss://web.dev/updates");
   }
 });
 ```
@@ -607,25 +632,25 @@ Track navigation timing with `performance.getEntriesByType('navigation')`:
 
 ```js copy
 // Track bfcache restoration in RUM
-window.addEventListener('pageshow', (event) => {
+window.addEventListener("pageshow", (event) => {
   if (event.persisted) {
     // Page restored from bfcache
-    gtag('event', 'bfcache_restoration', {
-      navigation_type: 'back_forward',
+    gtag("event", "bfcache_restoration", {
+      navigation_type: "back_forward",
       duration: 0,
     });
   }
 });
 
 // Track bfcache eligibility
-const navEntry = performance.getEntriesByType('navigation')[0];
+const navEntry = performance.getEntriesByType("navigation")[0];
 if (navEntry && navEntry.notRestoredReasons) {
   const blocked = navEntry.notRestoredReasons.blocked;
   const reasons = navEntry.notRestoredReasons.reasons || [];
 
-  gtag('event', 'bfcache_eligibility', {
+  gtag("event", "bfcache_eligibility", {
     blocked: blocked,
-    reasons: reasons.join(', '),
+    reasons: reasons.join(", "),
   });
 }
 ```

--- a/pages/Loading/Cache-Strategy-Analysis.mdx
+++ b/pages/Loading/Cache-Strategy-Analysis.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/Cache-Strategy-Analysis.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/Cache-Strategy-Analysis.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # Cache Strategy Analysis
 
@@ -34,12 +34,12 @@ flowchart TD
 
 **Why caching matters for performance:**
 
-| Metric | Impact |
-|--------|--------|
-| LCP | Cached resources load instantly — no network round-trip |
-| TTFB | CDN cache hits dramatically reduce server response time |
-| Bandwidth | Cached resources don't consume data (mobile users benefit) |
-| Repeat visits | Good caching makes subsequent page loads near-instant |
+| Metric        | Impact                                                     |
+| ------------- | ---------------------------------------------------------- |
+| LCP           | Cached resources load instantly — no network round-trip    |
+| TTFB          | CDN cache hits dramatically reduce server response time    |
+| Bandwidth     | Cached resources don't consume data (mobile users benefit) |
+| Repeat visits | Good caching makes subsequent page loads near-instant      |
 
 ### Snippet
 
@@ -51,20 +51,20 @@ flowchart TD
 
 Every resource is classified into one of these strategies:
 
-| Strategy | Cache-Control directive | Typical use case |
-|---------|------------------------|-----------------|
-| `immutable` | `max-age=31536000, immutable` | Versioned/hashed static assets |
-| `long` | `max-age > 86400` (> 1 day) | Static assets with long lifetime |
-| `medium` | `max-age 3600–86400` (1h–1d) | Semi-static content |
-| `short` | `max-age < 3600` (< 1h) | Frequently updated content |
-| `swr` | `stale-while-revalidate` | Content served stale while background refresh |
-| `must-revalidate` | `must-revalidate` + ETag/Last-Modified | Documents that must be fresh |
-| `no-cache` | `no-cache` or `max-age=0` | Forces revalidation every request |
-| `no-store` | `no-store` | Never cached (sensitive data) |
-| `expires-only` | Only `Expires` header, no `Cache-Control` | Legacy servers (outdated) |
-| `none` | No caching headers at all | Missing cache configuration |
-| `unknown (CORS)` | Cross-origin, headers not readable | Add `Timing-Allow-Origin` for visibility |
-| `cached (inferred)` | `transferSize=0` but no readable headers | Browser cached, strategy unknown |
+| Strategy            | Cache-Control directive                   | Typical use case                              |
+| ------------------- | ----------------------------------------- | --------------------------------------------- |
+| `immutable`         | `max-age=31536000, immutable`             | Versioned/hashed static assets                |
+| `long`              | `max-age > 86400` (> 1 day)               | Static assets with long lifetime              |
+| `medium`            | `max-age 3600–86400` (1h–1d)              | Semi-static content                           |
+| `short`             | `max-age < 3600` (< 1h)                   | Frequently updated content                    |
+| `swr`               | `stale-while-revalidate`                  | Content served stale while background refresh |
+| `must-revalidate`   | `must-revalidate` + ETag/Last-Modified    | Documents that must be fresh                  |
+| `no-cache`          | `no-cache` or `max-age=0`                 | Forces revalidation every request             |
+| `no-store`          | `no-store`                                | Never cached (sensitive data)                 |
+| `expires-only`      | Only `Expires` header, no `Cache-Control` | Legacy servers (outdated)                     |
+| `none`              | No caching headers at all                 | Missing cache configuration                   |
+| `unknown (CORS)`    | Cross-origin, headers not readable        | Add `Timing-Allow-Origin` for visibility      |
+| `cached (inferred)` | `transferSize=0` but no readable headers  | Browser cached, strategy unknown              |
 
 The **Cache Efficiency Score** shows what percentage of resources have an effective cache strategy (`immutable`, `long`, `medium`, `swr`, or `must-revalidate`).
 
@@ -83,28 +83,28 @@ Resources with `max-age < 3600` (less than 1 hour). Pay attention to:
 
 ### Cache Anti-patterns
 
-| Pattern | Severity | Meaning |
-|---------|----------|---------|
-| `static-no-store` | 🔴 Error | A JS, CSS, font, or image file has `no-store` — these should always be cacheable |
-| `large-no-cache` | 🔴 Error | A resource > 100 KB has no cache — significant bandwidth waste per visit |
-| `versioned-short-cache` | 🟡 Warning | A hashed URL has `max-age < 86400` — safe to use much longer TTL |
-| `expires-without-cc` | 🟡 Warning | Uses only `Expires` header — outdated, less reliable than `Cache-Control` |
-| `maxage-zero-static` | 🟡 Warning | Static asset with `max-age=0` — browser revalidates on every request |
-| `short-cache-static` | 🟡 Warning | Static asset with `max-age < 3600` — increase TTL for better performance |
-| `versioned-not-immutable` | 🔵 Info | Hashed URL without `immutable` — adding it avoids conditional GET requests |
+| Pattern                   | Severity   | Meaning                                                                          |
+| ------------------------- | ---------- | -------------------------------------------------------------------------------- |
+| `static-no-store`         | 🔴 Error   | A JS, CSS, font, or image file has `no-store` — these should always be cacheable |
+| `large-no-cache`          | 🔴 Error   | A resource > 100 KB has no cache — significant bandwidth waste per visit         |
+| `versioned-short-cache`   | 🟡 Warning | A hashed URL has `max-age < 86400` — safe to use much longer TTL                 |
+| `expires-without-cc`      | 🟡 Warning | Uses only `Expires` header — outdated, less reliable than `Cache-Control`        |
+| `maxage-zero-static`      | 🟡 Warning | Static asset with `max-age=0` — browser revalidates on every request             |
+| `short-cache-static`      | 🟡 Warning | Static asset with `max-age < 3600` — increase TTL for better performance         |
+| `versioned-not-immutable` | 🔵 Info    | Hashed URL without `immutable` — adding it avoids conditional GET requests       |
 
 ### CDN Cache Status
 
 Reads CDN-specific response headers to determine cache hit/miss per resource:
 
-| Header | CDN detected |
-|--------|-------------|
-| `CF-Cache-Status` | Cloudflare |
-| `X-Vercel-Cache` | Vercel Edge Network |
-| `X-Cache` | CloudFront or generic CDN |
-| `Age` | Generic proxy/CDN (presence = served from cache) |
-| `Via` | Any HTTP proxy |
-| `Server-Timing` | CDN that exposes cache info in Server-Timing |
+| Header            | CDN detected                                     |
+| ----------------- | ------------------------------------------------ |
+| `CF-Cache-Status` | Cloudflare                                       |
+| `X-Vercel-Cache`  | Vercel Edge Network                              |
+| `X-Cache`         | CloudFront or generic CDN                        |
+| `Age`             | Generic proxy/CDN (presence = served from cache) |
+| `Via`             | Any HTTP proxy                                   |
+| `Server-Timing`   | CDN that exposes cache info in Server-Timing     |
 
 A **CDN hit rate below 70%** usually indicates the CDN cache is cold, the TTL is too short, or cache-busting headers (`Cache-Control: no-store`, `Vary: *`) are preventing caching at the edge.
 
@@ -114,7 +114,7 @@ Header inspection (`Cache-Control`, `Expires`, CDN headers) requires issuing `HE
 
 ### Cross-origin resources
 
-Resources served from a different origin (different scheme, host, or port) than the current page are blocked by CORS unless the server sends `Access-Control-Allow-Origin`. This includes subdomains — `api.example.com` is cross-origin from `www.example.com`.
+Resources served from a different origin (different scheme, host, or port) than the current page are blocked by CORS unless the server sends `Access-Control-Allow-Origin`. This includes subdomains — `api.web.dev` is cross-origin from `www.web.dev`.
 
 Those resources appear as **"CORS-restricted"** in the output.
 

--- a/pages/Loading/Client-Side-Redirect-Detection.mdx
+++ b/pages/Loading/Client-Side-Redirect-Detection.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/Client-Side-Redirect-Detection.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/Client-Side-Redirect-Detection.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # Client-Side Redirect Detection
 
@@ -19,18 +19,18 @@ Client-side redirects are one of the most impactful but hardest-to-detect perfor
 
 **Common patterns that trigger client-side redirects:**
 
-| Pattern | Example | Impact |
-|---------|---------|--------|
-| **Language detection** | `/` loads JS → redirects to `/es/` | Very high - entire page load wasted |
-| **A/B testing** | Landing page → JS decides variant → redirects | High - experiment framework overhead |
-| **Authentication check** | Public URL → JS checks auth → redirects to login | Moderate - blocking on auth check |
-| **Legacy URLs** | Old URL → JS maps to new URL → redirects | High - should use 301 instead |
-| **SPA routing** | Deep link → app loads → client router takes over | Low to moderate - depends on bundle size |
+| Pattern                  | Example                                          | Impact                                   |
+| ------------------------ | ------------------------------------------------ | ---------------------------------------- |
+| **Language detection**   | `/` loads JS → redirects to `/es/`               | Very high - entire page load wasted      |
+| **A/B testing**          | Landing page → JS decides variant → redirects    | High - experiment framework overhead     |
+| **Authentication check** | Public URL → JS checks auth → redirects to login | Moderate - blocking on auth check        |
+| **Legacy URLs**          | Old URL → JS maps to new URL → redirects         | High - should use 301 instead            |
+| **SPA routing**          | Deep link → app loads → client router takes over | Low to moderate - depends on bundle size |
 
 **Real-world example:**
 
 ```
-User navigates to: https://example.com/
+User navigates to: https://web.dev/
 
 ❌ What happens with client-side redirect:
 • / responds with 2 KB HTML (757ms)
@@ -92,14 +92,15 @@ sequenceDiagram
 
 Shows the current URL, path, and referrer information. If the referrer is from the same origin but a different path, this suggests a potential client-side redirect.
 
-| Field | Description |
-|-------|-------------|
-| URL | Full current URL |
-| Path | Current pathname |
-| Referrer | Previous page URL (if available) |
-| Referrer path | Previous pathname |
+| Field         | Description                      |
+| ------------- | -------------------------------- |
+| URL           | Full current URL                 |
+| Path          | Current pathname                 |
+| Referrer      | Previous page URL (if available) |
+| Referrer path | Previous pathname                |
 
 **No referrer** can mean:
+
 - Direct navigation (user typed URL or used bookmark)
 - Navigation from HTTPS → HTTP (browsers hide referrer)
 - Referrer blocked by `Referrer-Policy`
@@ -108,22 +109,25 @@ Shows the current URL, path, and referrer information. If the referrer is from t
 
 Detects HTTP 301/302/307/308 redirects using the Navigation Timing API.
 
-| Status | Meaning |
-|--------|---------|
-| ✅ No server-side redirects | Direct navigation, optimal |
-| ⚠️ N redirect(s) detected | HTTP redirects occurred - check if necessary |
+| Status                      | Meaning                                      |
+| --------------------------- | -------------------------------------------- |
+| ✅ No server-side redirects | Direct navigation, optimal                   |
+| ⚠️ N redirect(s) detected   | HTTP redirects occurred - check if necessary |
 
 **Impact:**
+
 - Each redirect adds one round-trip (50-300ms typically)
 - Redirect chains (A→B→C) multiply the cost
 - Mobile/slow connections amplify the impact
 
 **When redirects are acceptable:**
+
 - HTTPS enforcement (HTTP→HTTPS)
 - www canonicalization (www→non-www or vice versa)
 - Temporary redirects for maintenance (302)
 
 **When to avoid:**
+
 - Chains of 3+ redirects
 - Client-side redirects that could be server-side
 - Redirects on every page load
@@ -132,13 +136,13 @@ Detects HTTP 301/302/307/308 redirects using the Navigation Timing API.
 
 The snippet checks multiple signals to detect client-side redirects:
 
-| Indicator | What it detects | Severity |
-|-----------|----------------|----------|
-| **Same-origin navigation** | Referrer from same domain, different path | ⚠️ Warning |
-| **Document navigation** | Same-origin page loads detected in Resource Timing (excludes third-party iframes) | 🔴 Error |
-| **Redirect parameter** | URL contains `?redirect=`, `?from=`, etc. | ℹ️ Info |
-| **SPA router detected** | History API state present | ℹ️ Info |
-| **Fast minimal-content navigation** | Small page (&lt;10KB) loaded quickly (&lt;500ms) - likely a redirect page | ⚠️ Warning |
+| Indicator                           | What it detects                                                                   | Severity   |
+| ----------------------------------- | --------------------------------------------------------------------------------- | ---------- |
+| **Same-origin navigation**          | Referrer from same domain, different path                                         | ⚠️ Warning |
+| **Document navigation**             | Same-origin page loads detected in Resource Timing (excludes third-party iframes) | 🔴 Error   |
+| **Redirect parameter**              | URL contains `?redirect=`, `?from=`, etc.                                         | ℹ️ Info    |
+| **SPA router detected**             | History API state present                                                         | ℹ️ Info    |
+| **Fast minimal-content navigation** | Small page (&lt;10KB) loaded quickly (&lt;500ms) - likely a redirect page         | ⚠️ Warning |
 
 **Severity levels:**
 
@@ -153,7 +157,7 @@ The snippet checks multiple signals to detect client-side redirects:
    ⚠️ 2 indicator(s) found
 
    🔴 Document navigation
-      url: https://example.com/es/
+      url: https://web.dev/es/
       duration: 2430.5ms
 
    ⚠️ Same-origin navigation
@@ -165,11 +169,11 @@ The snippet checks multiple signals to detect client-side redirects:
 
 When client-side redirects are detected, the snippet estimates their impact on LCP:
 
-| Impact Level | Overhead | Rating | Action |
-|--------------|----------|--------|--------|
-| **CRITICAL** | &gt; 3000ms | 🔴 | Fix immediately - major LCP issue |
-| **MODERATE** | 1000-3000ms | 🟡 | High priority - noticeable delay |
-| **LOW** | &lt; 1000ms | 🟢 | Monitor - may be acceptable for SPAs |
+| Impact Level | Overhead    | Rating | Action                               |
+| ------------ | ----------- | ------ | ------------------------------------ |
+| **CRITICAL** | &gt; 3000ms | 🔴     | Fix immediately - major LCP issue    |
+| **MODERATE** | 1000-3000ms | 🟡     | High priority - noticeable delay     |
+| **LOW**      | &lt; 1000ms | 🟢     | Monitor - may be acceptable for SPAs |
 
 **Calculating overhead:**
 
@@ -180,11 +184,13 @@ The overhead is the total duration of all document navigations detected in the R
 The snippet provides actionable recommendations based on the redirect type:
 
 **For server-side redirects:**
+
 - Minimize redirect chains
 - Use direct links in your HTML/marketing campaigns
 - Cache redirect responses
 
 **For client-side redirects:**
+
 - Replace with HTTP 301 (permanent) or 302 (temporary)
 - Use language detection at the server/CDN level
 - Implement redirects in Nginx, Apache, or CDN config
@@ -197,15 +203,15 @@ See your web server documentation for implementing 301/302 redirects with langua
 
 Provides a complete breakdown of the current page load:
 
-| Metric | Description |
-|--------|-------------|
-| TTFB | Time to First Byte - server response time |
-| DOM Content Loaded | When HTML is parsed and DOM is ready |
-| Load Complete | When all resources finish loading |
-| Redirect Time | Time spent following redirects (if any) |
-| DNS Lookup | Domain name resolution time |
-| TCP Connect | Connection establishment time |
-| Request/Response | Time to receive the response |
+| Metric             | Description                               |
+| ------------------ | ----------------------------------------- |
+| TTFB               | Time to First Byte - server response time |
+| DOM Content Loaded | When HTML is parsed and DOM is ready      |
+| Load Complete      | When all resources finish loading         |
+| Redirect Time      | Time spent following redirects (if any)   |
+| DNS Lookup         | Domain name resolution time               |
+| TCP Connect        | Connection establishment time             |
+| Request/Response   | Time to receive the response              |
 
 #### Document Navigations Table
 
@@ -213,19 +219,20 @@ If same-origin document navigations are detected, shows detailed timing for each
 
 **Note:** Third-party iframes (analytics, ads, etc.) are automatically excluded from this analysis.
 
-| Column | Description |
-|--------|-------------|
-| Type | `navigation` (same-origin page navigations) |
-| Duration | Total time from start to load complete |
-| TTFB | Time to first byte for this navigation |
-| Transfer | Bytes transferred over the network |
-| URL | The navigation URL (same origin as current page) |
+| Column   | Description                                      |
+| -------- | ------------------------------------------------ |
+| Type     | `navigation` (same-origin page navigations)      |
+| Duration | Total time from start to load complete           |
+| TTFB     | Time to first byte for this navigation           |
+| Transfer | Bytes transferred over the network               |
+| URL      | The navigation URL (same origin as current page) |
 
 ### How to Use This Snippet
 
 **1. Detect redirects on landing pages:**
 
 Navigate to your site's homepage or common landing pages and run the snippet. Look for:
+
 - Same-origin navigation indicators
 - Document navigation entries
 - High performance impact
@@ -253,6 +260,7 @@ Compare: Is Test 2 significantly slower?
 **4. Validate after fixes:**
 
 After implementing server-side redirects:
+
 - Retest with the snippet
 - Verify no document navigation entries
 - Confirm server-side redirects show in the "Server-Side Redirects" section
@@ -260,33 +268,37 @@ After implementing server-side redirects:
 
 ### Browser Support
 
-| Feature | Chrome | Edge | Firefox | Safari |
-|---------|--------|------|---------|--------|
-| Navigation Timing | 57 | 12 | 58 | 11 |
-| Resource Timing | 43 | 12 | 40 | 11 |
-| document.referrer | All | All | All | All |
+| Feature           | Chrome | Edge | Firefox | Safari |
+| ----------------- | ------ | ---- | ------- | ------ |
+| Navigation Timing | 57     | 12   | 58      | 11     |
+| Resource Timing   | 43     | 12   | 40      | 11     |
+| document.referrer | All    | All  | All     | All    |
 
 The snippet works in all modern browsers. Older browsers may show reduced information.
 
 ### Limitations
 
 **Cannot detect:**
+
 - Meta refresh redirects (`<meta http-equiv="refresh">`)
 - Redirects that happen before the page loads
 - Some SPA router navigations that don't create resource entries
 - History.pushState/replaceState navigations without full page loads
 
 **Automatically filtered out:**
+
 - Third-party iframes (analytics, ads, social widgets)
 - Cross-origin navigations
 - Standard iframe embeds
 
 **False positives:**
+
 - SPAs that legitimately use client-side routing
 - Preview/staging environments with redirect parameters
 - A/B testing platforms that use URL parameters
 
 **Accuracy notes:**
+
 - Performance impact is estimated based on detected navigation entries
 - Actual LCP impact may vary based on resource loading patterns
 - Some redirect patterns may not leave traces in Performance APIs

--- a/pages/Loading/Find-render-blocking-resources.mdx
+++ b/pages/Loading/Find-render-blocking-resources.mdx
@@ -3,15 +3,13 @@ import { Snippet } from '../../components/Snippet'
 
 # Find render-blocking resources
 
-### Overview
-
 Identifies resources that block the browser from rendering the page. These resources must be fully downloaded and processed before the browser can display any content, directly impacting First Contentful Paint (FCP) and Largest Contentful Paint (LCP).
 
-**Why this matters:**
+### Why this matters
 
 Render-blocking resources are the primary cause of slow initial page renders. Users see a blank white screen while CSS and JavaScript files download and parse. On slow connections or mobile networks, this can add several seconds to your load time. Eliminating or deferring render-blocking resources is one of the highest-impact optimizations you can make.
 
-**What are render-blocking resources?**
+### What are render-blocking resources?
 
 | Resource Type | When it blocks rendering |
 |---------------|-------------------------|
@@ -19,14 +17,14 @@ Render-blocking resources are the primary cause of slow initial page renders. Us
 | **JavaScript** | Scripts without `async` or `defer` in `<head>` block parsing and rendering |
 | **Fonts** | `@font-face` fonts block text rendering until loaded |
 
-**Impact on performance:**
+### Impact on performance
 
 - Delays First Contentful Paint (FCP)
 - Can delay Largest Contentful Paint (LCP)
 - Users see a blank page while resources load
 - Particularly harmful on slow connections
 
-**Render-Blocking Timeline:**
+### Render-blocking timeline
 
 ```mermaid
 sequenceDiagram
@@ -59,15 +57,15 @@ sequenceDiagram
     Note over Browser,Render: User sees content
 ```
 
-> **Browser Support:** The `renderBlockingStatus` property is currently Chromium-only (Chrome 107+, Edge 107+, Opera 93+). Firefox and Safari don't support this API yet.
+> **Browser support:** The `renderBlockingStatus` property is currently Chromium-only (Chrome 107+, Edge 107+, Opera 93+). Firefox and Safari don't support this API yet.
 
 ### Snippet
 
 <Snippet code={snippet} />
 
-### Understanding the Results
+### Understanding the results
 
-**Summary Metrics:**
+### Summary metrics
 
 | Metric | Description |
 |--------|-------------|
@@ -76,7 +74,7 @@ sequenceDiagram
 | **Total size** | Combined transfer size of all blocking resources |
 | **By type** | Breakdown by resource type (script, link/css, font) |
 
-**Timeline Visualization:**
+### Timeline visualization
 
 Shows each resource with:
 - Resource type
@@ -86,7 +84,7 @@ Shows each resource with:
 
 Resources are sorted by completion time (latest first), so you can see which resource is the last to complete and thus determines when rendering can start.
 
-### Optimization Decision Tree
+### Optimization decision tree
 
 ```mermaid
 flowchart TD
@@ -116,9 +114,9 @@ flowchart TD
     style Preload fill:#E5FFE5
 ```
 
-### Common Render-Blocking Patterns
+### Common render-blocking patterns
 
-**Scripts in `<head>` without defer/async:**
+### Scripts in `<head>` without defer/async
 
 ```html
 <!-- ❌ Render-blocking -->
@@ -132,7 +130,7 @@ flowchart TD
 </head>
 ```
 
-**External stylesheets:**
+### External stylesheets
 
 ```html
 <!-- ❌ Render-blocking (but often necessary) -->
@@ -143,7 +141,7 @@ flowchart TD
 <noscript><link rel="stylesheet" href="non-critical.css"></noscript>
 ```
 
-**Web fonts:**
+### Web fonts
 
 ```css
 /* ❌ Blocks text rendering */
@@ -160,7 +158,7 @@ flowchart TD
 }
 ```
 
-### Further Reading
+### Further reading
 
 - [Eliminate render-blocking resources](https://developer.chrome.com/docs/lighthouse/performance/render-blocking-resources) | Chrome Developers
 - [Render-blocking CSS](https://web.dev/articles/critical-rendering-path/render-blocking-css) | web.dev

--- a/pages/Loading/First-And-Third-Party-Script-Info.mdx
+++ b/pages/Loading/First-And-Third-Party-Script-Info.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/First-And-Third-Party-Script-Info.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/First-And-Third-Party-Script-Info.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # First And Third Party Script Info
 
@@ -7,13 +7,13 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 
 **Why this matters:**
 
-| Concern | First-Party | Third-Party |
-|---------|-------------|-------------|
-| **Control** | Full control over optimization | Limited or no control |
-| **Reliability** | Depends on your infrastructure | External point of failure |
+| Concern         | First-Party                       | Third-Party                            |
+| --------------- | --------------------------------- | -------------------------------------- |
+| **Control**     | Full control over optimization    | Limited or no control                  |
+| **Reliability** | Depends on your infrastructure    | External point of failure              |
 | **Performance** | Can be optimized, bundled, cached | Often unoptimized, may block rendering |
-| **Privacy** | Your data policies | May collect user data |
-| **Security** | Your responsibility | Potential vulnerability vector |
+| **Privacy**     | Your data policies                | May collect user data                  |
+| **Security**    | Your responsibility               | Potential vulnerability vector         |
 
 **Common third-party script issues:**
 
@@ -32,50 +32,53 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 ### Understanding the Results
 
 **Overall Summary:**
+
 - Total script count with first/third-party breakdown
 - Warning if third-party scripts outnumber first-party
 
 **First-Party Scripts:**
+
 - Scripts from your domain and subdomains (auto-detected)
 - Total size and render-blocking count
 
 **Third-Party Scripts:**
+
 - Scripts from external domains
 - Grouped by host to identify heavy dependencies
 - Total size, render-blocking count, unique hosts
 
 **For each script:**
 
-| Field | Description |
-|-------|-------------|
-| Script | Filename |
-| Host | Domain serving the script |
-| Size | Transfer size (compressed) |
-| Duration | Total time to load |
+| Field    | Description                 |
+| -------- | --------------------------- |
+| Script   | Filename                    |
+| Host     | Domain serving the script   |
+| Size     | Transfer size (compressed)  |
+| Duration | Total time to load          |
 | Blocking | Whether it blocks rendering |
 
 ### How First-Party Detection Works
 
 The snippet automatically detects first-party scripts by comparing root domains:
 
-| Page Domain | Script Host | Detected As |
-|-------------|-------------|-------------|
-| `example.com` | `example.com` | First-party |
-| `example.com` | `cdn.example.com` | First-party |
-| `example.com` | `assets.example.com` | First-party |
-| `example.com` | `google-analytics.com` | Third-party |
-| `shop.example.co.uk` | `cdn.example.co.uk` | First-party |
+| Page Domain          | Script Host            | Detected As |
+| -------------------- | ---------------------- | ----------- |
+| `web.dev`            | `web.dev`              | First-party |
+| `web.dev`            | `cdn.web.dev`          | First-party |
+| `web.dev`            | `assets.web.dev`       | First-party |
+| `web.dev`            | `google-analytics.com` | Third-party |
+| `shop.example.co.uk` | `cdn.example.co.uk`    | First-party |
 
 ### Common Third-Party Script Categories
 
-| Category | Examples | Typical Impact |
-|----------|----------|----------------|
-| Analytics | Google Analytics, Segment, Mixpanel | 20-50 KB, often async |
-| Advertising | Google Ads, Facebook Pixel | 50-200 KB, may chain-load |
-| Tag Managers | GTM, Tealium | 30-80 KB, loads additional scripts |
-| Social | Facebook SDK, Twitter widgets | 100-300 KB, heavy |
-| Chat/Support | Intercom, Zendesk, Drift | 100-500 KB, often deferred |
-| A/B Testing | Optimizely, VWO | 50-150 KB, often blocking |
+| Category     | Examples                            | Typical Impact                     |
+| ------------ | ----------------------------------- | ---------------------------------- |
+| Analytics    | Google Analytics, Segment, Mixpanel | 20-50 KB, often async              |
+| Advertising  | Google Ads, Facebook Pixel          | 50-200 KB, may chain-load          |
+| Tag Managers | GTM, Tealium                        | 30-80 KB, loads additional scripts |
+| Social       | Facebook SDK, Twitter widgets       | 100-300 KB, heavy                  |
+| Chat/Support | Intercom, Zendesk, Drift            | 100-500 KB, often deferred         |
+| A/B Testing  | Optimizely, VWO                     | 50-150 KB, often blocking          |
 
 ### Further Reading
 

--- a/pages/Loading/Resource-Hints-Validation.mdx
+++ b/pages/Loading/Resource-Hints-Validation.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/Resource-Hints-Validation.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/Resource-Hints-Validation.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # Resource Hints Validation
 
@@ -11,24 +11,25 @@ Validates resource hints (preload, preconnect, dns-prefetch) by analyzing which 
 
 Resource hints tell the browser to perform actions that can improve loading performance:
 
-| Hint           | Purpose                                       | When to Use                         |
-| -------------- | --------------------------------------------- | ----------------------------------- |
-| `preload`      | Load critical resources early, high priority  | Current page critical resources     |
-| `preconnect`   | Establish connection (DNS + TCP + TLS)        | Critical third-party domains        |
-| `dns-prefetch` | Resolve DNS only                              | Non-critical third-party domains    |
+| Hint           | Purpose                                      | When to Use                      |
+| -------------- | -------------------------------------------- | -------------------------------- |
+| `preload`      | Load critical resources early, high priority | Current page critical resources  |
+| `preconnect`   | Establish connection (DNS + TCP + TLS)       | Critical third-party domains     |
+| `dns-prefetch` | Resolve DNS only                             | Non-critical third-party domains |
 
 **Problems commonly detected:**
 
-| Issue                         | Impact                         | Detection                                |
-| ----------------------------- | ------------------------------ | ---------------------------------------- |
-| **Unused preload**            | Wasted bandwidth               | Preload declared but resource not used   |
-| **Unused preconnect**         | Wasted CPU/network             | Connection opened but domain not used    |
-| **Unused dns-prefetch**       | Minimal waste                  | DNS resolved but domain not used         |
-| **Missing preconnect**        | Opportunity loss               | Domain used but no preconnect hint       |
+| Issue                   | Impact             | Detection                              |
+| ----------------------- | ------------------ | -------------------------------------- |
+| **Unused preload**      | Wasted bandwidth   | Preload declared but resource not used |
+| **Unused preconnect**   | Wasted CPU/network | Connection opened but domain not used  |
+| **Unused dns-prefetch** | Minimal waste      | DNS resolved but domain not used       |
+| **Missing preconnect**  | Opportunity loss   | Domain used but no preconnect hint     |
 
 ### Important Notes
 
 **Timing**: Run this snippet after the page has fully loaded and all resources are in the Performance API. For best results:
+
 - Wait until `window.addEventListener('load', ...)` fires
 - Or wait a few seconds after initial page load
 - Resources like fonts may load asynchronously and won't appear immediately
@@ -36,6 +37,7 @@ Resource hints tell the browser to perform actions that can improve loading perf
 **Why timing matters**: The snippet compares declared hints against resources captured by `performance.getEntriesByType("resource")`. If resources haven't loaded yet when you run the snippet, they won't be detected as "used" even though they will load later.
 
 **Performance API Limitations**: Some resources may not appear in the Performance API even when they're loaded:
+
 - **Lazy-loaded images**: Images loaded via Intersection Observer or similar techniques may not be captured
 - **Service Worker cached resources**: Resources served from service worker cache might not be recorded
 - **Cross-origin restrictions**: Some third-party resources without `Timing-Allow-Origin` headers have limited visibility
@@ -81,11 +83,11 @@ Shows the overall state of resource hints:
 
 ### When to Use Each Hint
 
-| Hint | Use Case | Request Count |
-| ---- | -------- | ------------- |
-| `preload` | Critical same-origin resources (fonts, hero images) | Any |
-| `preconnect` | Critical third-party domains (CDN) | 5+ requests recommended |
-| `dns-prefetch` | Non-critical third-party (analytics, ads) | 2-4 requests |
+| Hint           | Use Case                                            | Request Count           |
+| -------------- | --------------------------------------------------- | ----------------------- |
+| `preload`      | Critical same-origin resources (fonts, hero images) | Any                     |
+| `preconnect`   | Critical third-party domains (CDN)                  | 5+ requests recommended |
+| `dns-prefetch` | Non-critical third-party (analytics, ads)           | 2-4 requests            |
 
 ### Real-World Examples
 
@@ -93,28 +95,28 @@ Shows the overall state of resource hints:
 
 ```html
 <!-- Preload critical resources -->
-<link rel="preload" href="/fonts/main.woff2" as="font" crossorigin>
-<link rel="preload" href="/hero-image.webp" as="image">
+<link rel="preload" href="/fonts/main.woff2" as="font" crossorigin />
+<link rel="preload" href="/hero-image.webp" as="image" />
 
 <!-- Conditional preload for responsive images -->
-<link rel="preload" href="/hero-mobile.webp" as="image" media="(max-width: 768px)">
-<link rel="preload" href="/hero-desktop.webp" as="image" media="(min-width: 769px)">
+<link rel="preload" href="/hero-mobile.webp" as="image" media="(max-width: 768px)" />
+<link rel="preload" href="/hero-desktop.webp" as="image" media="(min-width: 769px)" />
 
 <!-- Preconnect to critical CDN -->
-<link rel="preconnect" href="https://cdn.example.com">
+<link rel="preconnect" href="https://cdn.web.dev" />
 
 <!-- DNS-prefetch for analytics -->
-<link rel="dns-prefetch" href="https://analytics.example.com">
+<link rel="dns-prefetch" href="https://analytics.web.dev" />
 ```
 
 **❌ Bad: Unused hints**
 
 ```html
 <!-- Preload for resource not used on this page -->
-<link rel="preload" href="/admin-panel.js" as="script">
+<link rel="preload" href="/admin-panel.js" as="script" />
 
 <!-- Preconnect to domain never accessed -->
-<link rel="preconnect" href="https://unused-cdn.example.com">
+<link rel="preconnect" href="https://unused-cdn.web.dev" />
 ```
 
 ### Further Reading

--- a/pages/Loading/Validate-Preload-Async-Defer-Scripts.mdx
+++ b/pages/Loading/Validate-Preload-Async-Defer-Scripts.mdx
@@ -1,5 +1,5 @@
-import snippet from '../../snippets/Loading/Validate-Preload-Async-Defer-Scripts.js?raw'
-import { Snippet } from '../../components/Snippet'
+import snippet from "../../snippets/Loading/Validate-Preload-Async-Defer-Scripts.js?raw";
+import { Snippet } from "../../components/Snippet";
 
 # Validate Preload on Async/Defer Scripts
 
@@ -269,8 +269,8 @@ A common scenario where this anti-pattern appears is with third-party consent ma
 
 ```html
 <!-- ❌ Anti-pattern: Preload + async without mitigation -->
-<link rel="preload" href="https://cdn.example.com/consent.js" as="script" />
-<script async src="https://cdn.example.com/consent.js"></script>
+<link rel="preload" href="https://cdn.web.dev/consent.js" as="script" />
+<script async src="https://cdn.web.dev/consent.js"></script>
 ```
 
 **Why developers do this:**
@@ -299,7 +299,7 @@ Some developers consider using `fetchpriority="high"` instead:
 
 ```html
 <!-- ⚠️ Still problematic -->
-<script async src="https://cdn.example.com/consent.js" fetchpriority="high"></script>
+<script async src="https://cdn.web.dev/consent.js" fetchpriority="high"></script>
 ```
 
 **Why this doesn't solve the problem:**
@@ -327,8 +327,8 @@ If you truly need early discovery but don't want priority escalation:
 
 ```html
 <!-- ✅ Early discovery + low priority -->
-<link rel="preload" href="https://cdn.example.com/consent.js" as="script" fetchpriority="low" />
-<script async src="https://cdn.example.com/consent.js" fetchpriority="low"></script>
+<link rel="preload" href="https://cdn.web.dev/consent.js" as="script" fetchpriority="low" />
+<script async src="https://cdn.web.dev/consent.js" fetchpriority="low"></script>
 ```
 
 **How this works:**
@@ -359,7 +359,7 @@ If the script tag is already in `<head>`, preload may not be necessary:
 ```html
 <!-- ✅ Simple and effective if script is in <head> -->
 <head>
-  <script async src="https://cdn.example.com/consent.js"></script>
+  <script async src="https://cdn.web.dev/consent.js"></script>
   <!-- Other head content -->
 </head>
 ```

--- a/pages/_meta.json
+++ b/pages/_meta.json
@@ -19,5 +19,8 @@
   },
   "DevTools-Overrides": {
     "title": "DevTools Overrides"
+  },
+  "CLI": {
+    "title": "CLI"
   }
 }

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -21,13 +21,13 @@ A curated collection of JavaScript snippets to measure and debug Web Performance
 
 ## What you can measure
 
-| Category | What it includes |
-|----------|------------------|
-| **[Core Web Vitals](/CoreWebVitals/LCP)** | CLS, INP, LCP, LCP Image Entropy, LCP Sub-Parts, LCP Trail, LCP Video Candidate |
-| **[Loading](/Loading/TTFB)** | TTFB, JS Execution Time Breakdown, FCP, Back/Forward Cache, CSS Media Queries Analysis, Critical CSS Detection, SSR Hydration Data Analysis, Validate Preload on Async/Defer Scripts, Prefetch Resource Validation, Priority Hints Audit, Service Worker Analysis |
-| **[Interaction](/Interaction/Long-Animation-Frames)** | Interactions, Input Latency Breakdown, Layout Shift, Long Animation Frames, Long Task, Scroll Performance |
-| **[Resources](/Resources/Network-Bandwidth-Connection-Quality)** | Network Bandwidth & Connection Quality |
-| **[Media](/Media/Image-Element-Audit)** | Image Element Audit, Video Element Audit |
+| Category                                                         | What it includes                                                                                                                                                                                                                                                  |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[Core Web Vitals](/CoreWebVitals/LCP)**                        | CLS, INP, LCP, LCP Image Entropy, LCP Sub-Parts, LCP Trail, LCP Video Candidate                                                                                                                                                                                   |
+| **[Loading](/Loading/TTFB)**                                     | TTFB, JS Execution Time Breakdown, FCP, Back/Forward Cache, CSS Media Queries Analysis, Critical CSS Detection, SSR Hydration Data Analysis, Validate Preload on Async/Defer Scripts, Prefetch Resource Validation, Priority Hints Audit, Service Worker Analysis |
+| **[Interaction](/Interaction/Long-Animation-Frames)**            | Interactions, Input Latency Breakdown, Layout Shift, Long Animation Frames, Long Task, Scroll Performance                                                                                                                                                         |
+| **[Resources](/Resources/Network-Bandwidth-Connection-Quality)** | Network Bandwidth & Connection Quality                                                                                                                                                                                                                            |
+| **[Media](/Media/Image-Element-Audit)**                          | Image Element Audit, Video Element Audit                                                                                                                                                                                                                          |
 
 ## Quick Start
 
@@ -44,7 +44,9 @@ new PerformanceObserver((l) => {
 
 new PerformanceObserver((l) => {
   let cls = 0;
-  l.getEntries().forEach((e) => { if (!e.hadRecentInput) cls += e.value; });
+  l.getEntries().forEach((e) => {
+    if (!e.hadRecentInput) cls += e.value;
+  });
   console.log(`CLS: ${cls.toFixed(3)}`);
 }).observe({ type: "layout-shift", buffered: true });
 ```
@@ -97,18 +99,34 @@ Available skills: `webperf`, `webperf-core-web-vitals`, `webperf-loading`, `webp
 
 WebPerf Snippets powers a set of [Agent Skills](https://github.com/nucliweb/webperf-snippets/tree/main/.claude/skills) for autonomous performance audits. Instead of copying and pasting snippets manually, an AI agent executes them deterministically through Chrome DevTools MCP — the same code, every time, across sessions and models.
 
-| Skill | What it covers |
-|-------|---------------|
-| `webperf` | General-purpose performance audit entry point |
-| `webperf-core-web-vitals` | LCP, CLS, INP with guided diagnosis workflows |
-| `webperf-loading` | TTFB, FCP, render-blocking, fonts, scripts, resource hints |
-| `webperf-interaction` | INP, long tasks, scroll jank, animation frames |
-| `webperf-media` | Image and video audits, lazy loading, LCP media |
-| `webperf-resources` | Network quality, adaptive loading strategies |
+| Skill                     | What it covers                                             |
+| ------------------------- | ---------------------------------------------------------- |
+| `webperf`                 | General-purpose performance audit entry point              |
+| `webperf-core-web-vitals` | LCP, CLS, INP with guided diagnosis workflows              |
+| `webperf-loading`         | TTFB, FCP, render-blocking, fonts, scripts, resource hints |
+| `webperf-interaction`     | INP, long tasks, scroll jank, animation frames             |
+| `webperf-media`           | Image and video audits, lazy loading, LCP media            |
+| `webperf-resources`       | Network quality, adaptive loading strategies               |
 
 The skills include decision trees that automatically trigger deeper analysis when thresholds are exceeded — for example, when TTFB is slow, the agent runs TTFB sub-parts diagnostics to pinpoint whether the issue is DNS, connection, or backend latency.
 
 → [Read more about WebPerf Agent Skills](https://joanleon.dev/en/webperf-snippets-agent-skills/)
+
+## CLI
+
+Run the same curated snippets headlessly via Playwright — no copy-pasting into DevTools. Diagnose LCP regressions in CI, gate pull requests on real performance budgets, and automate the audits you already run by hand.
+
+```bash copy
+npx webperf-snippets https://web.dev --workflow audit
+npx webperf-snippets https://web.dev --budget-lcp 2500 --budget-cls 0.1
+```
+
+| Workflow          | What it runs                                                         |
+| ----------------- | -------------------------------------------------------------------- |
+| `core-web-vitals` | LCP, CLS — with automatic LCP-Subparts follow-up                     |
+| `audit`           | Render-blocking, resource hints, critical CSS, TTFB, scripts, images |
+
+→ [CLI documentation](/CLI)
 
 ## Resources
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5898,7 +5898,7 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
       console.log(`%c⚠️ ${thirdMetrics.hosts.length} different third-party hosts:`, "font-weight: bold; color: #f59e0b;");
       console.log("   • Each host requires DNS lookup + connection");
       console.log("   • Use <link rel='preconnect'> for critical hosts");
-      console.log('%c   <link rel="preconnect" href="https://example.com">', "font-family: monospace; color: #22c55e;");
+      console.log('%c   <link rel="preconnect" href="https://web.dev">', "font-family: monospace; color: #22c55e;");
     }
 
     if (thirdMetrics.totalSize > 100 * 1024) {

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -5713,6 +5713,9 @@ Identifies resources that block the browser from rendering the page. These resou
       durationMs: Math.round(r.duration),
       sizeBytes: r.size,
     })),
+    issues: blockingResources.length > 0
+      ? [{ severity: "error", message: `${blockingResources.length} render-blocking resource(s) delay rendering until ${Math.round(lastBlockingEnd)}ms` }]
+      : [],
   };
 })();
 ```
@@ -5794,10 +5797,14 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
   const firstMetrics = calcMetrics(firstParty);
   const thirdMetrics = calcMetrics(thirdParty);
   const totalScripts = scripts.length;
-  const thirdPartyPct = totalScripts > 0 ? ((thirdParty.length / totalScripts) * 100).toFixed(0) : 0;
+  const thirdPartyPct =
+    totalScripts > 0 ? ((thirdParty.length / totalScripts) * 100).toFixed(0) : 0;
 
   // Display results
-  console.group("%c📊 Script Analysis: First vs Third Party", "font-weight: bold; font-size: 14px;");
+  console.group(
+    "%c📊 Script Analysis: First vs Third Party",
+    "font-weight: bold; font-size: 14px;",
+  );
 
   // Overall summary
   console.log("");
@@ -5812,7 +5819,10 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 
   // First Party Section
   console.log("");
-  console.group(`%c🏠 First-Party Scripts (${firstParty.length})`, "color: #22c55e; font-weight: bold;");
+  console.group(
+    `%c🏠 First-Party Scripts (${firstParty.length})`,
+    "color: #22c55e; font-weight: bold;",
+  );
 
   if (firstParty.length === 0) {
     console.log("No first-party scripts found.");
@@ -5836,13 +5846,13 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 
   // Third Party Section
   console.log("");
-  console.group(`%c🌐 Third-Party Scripts (${thirdParty.length})`, "color: #ef4444; font-weight: bold;");
+  console.group(
+    `%c🌐 Third-Party Scripts (${thirdParty.length})`,
+    "color: #ef4444; font-weight: bold;",
+  );
 
   if (thirdParty.length === 0) {
-    console.log(
-      "%c✅ No third-party scripts found!",
-      "color: #22c55e; font-weight: bold;"
-    );
+    console.log("%c✅ No third-party scripts found!", "color: #22c55e; font-weight: bold;");
   } else {
     console.log(`   Total size: ${formatBytes(thirdMetrics.totalSize)}`);
     console.log(`   Render-blocking: ${thirdMetrics.blocking}`);
@@ -5863,7 +5873,9 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
       .sort((a, b) => b[1].size - a[1].size)
       .forEach(([host, data]) => {
         const blockingMark = data.blocking > 0 ? " ⚠️" : "";
-        console.log(`      ${host}: ${data.count} script(s), ${formatBytes(data.size)}${blockingMark}`);
+        console.log(
+          `      ${host}: ${data.count} script(s), ${formatBytes(data.size)}${blockingMark}`,
+        );
       });
 
     console.log("");
@@ -5887,23 +5899,38 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 
     if (thirdMetrics.blocking > 0) {
       console.log("");
-      console.log("%c⚠️ Render-blocking third-party scripts:", "font-weight: bold; color: #ef4444;");
+      console.log(
+        "%c⚠️ Render-blocking third-party scripts:",
+        "font-weight: bold; color: #ef4444;",
+      );
       console.log("   • Load with 'async' or 'defer' attribute");
       console.log("   • Consider lazy-loading after user interaction");
-      console.log('%c   <script src="..." async></script>', "font-family: monospace; color: #22c55e;");
+      console.log(
+        '%c   <script src="..." async></script>',
+        "font-family: monospace; color: #22c55e;",
+      );
     }
 
     if (thirdMetrics.hosts.length > 3) {
       console.log("");
-      console.log(`%c⚠️ ${thirdMetrics.hosts.length} different third-party hosts:`, "font-weight: bold; color: #f59e0b;");
+      console.log(
+        `%c⚠️ ${thirdMetrics.hosts.length} different third-party hosts:`,
+        "font-weight: bold; color: #f59e0b;",
+      );
       console.log("   • Each host requires DNS lookup + connection");
       console.log("   • Use <link rel='preconnect'> for critical hosts");
-      console.log('%c   <link rel="preconnect" href="https://web.dev">', "font-family: monospace; color: #22c55e;");
+      console.log(
+        '%c   <link rel="preconnect" href="https://web.dev">',
+        "font-family: monospace; color: #22c55e;",
+      );
     }
 
     if (thirdMetrics.totalSize > 100 * 1024) {
       console.log("");
-      console.log(`%c⚠️ Third-party scripts total ${formatBytes(thirdMetrics.totalSize)}:`, "font-weight: bold; color: #f59e0b;");
+      console.log(
+        `%c⚠️ Third-party scripts total ${formatBytes(thirdMetrics.totalSize)}:`,
+        "font-weight: bold; color: #f59e0b;",
+      );
       console.log("   • Audit necessity of each script");
       console.log("   • Consider self-hosting critical scripts");
       console.log("   • Look for lighter alternatives");
@@ -5934,11 +5961,39 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
       thirdPartyBlockingCount: thirdMetrics.blocking,
       thirdPartyHostCount: thirdMetrics.hosts.length,
     },
-    items: scripts.map(s => ({ shortName: s.shortName, host: s.host, firstParty: s.firstParty, transferBytes: s.transferSize, durationMs: Math.round(s.duration), renderBlocking: s.renderBlocking })),
+    items: scripts.map((s) => ({
+      shortName: s.shortName,
+      host: s.host,
+      firstParty: s.firstParty,
+      transferBytes: s.transferSize,
+      durationMs: Math.round(s.duration),
+      renderBlocking: s.renderBlocking,
+    })),
     issues: [
-      ...(thirdMetrics.blocking > 0 ? [{ severity: "error", message: `${thirdMetrics.blocking} render-blocking third-party script(s)` }] : []),
-      ...(thirdMetrics.hosts.length > 3 ? [{ severity: "warning", message: `${thirdMetrics.hosts.length} different third-party hosts require separate DNS lookups` }] : []),
-      ...(thirdMetrics.totalSize > 100 * 1024 ? [{ severity: "warning", message: `Third-party scripts total ${Math.round(thirdMetrics.totalSize / 1024)} KB` }] : []),
+      ...(thirdMetrics.blocking > 0
+        ? [
+            {
+              severity: "error",
+              message: `${thirdMetrics.blocking} render-blocking third-party script(s)`,
+            },
+          ]
+        : []),
+      ...(thirdMetrics.hosts.length > 3
+        ? [
+            {
+              severity: "warning",
+              message: `${thirdMetrics.hosts.length} different third-party hosts require separate DNS lookups`,
+            },
+          ]
+        : []),
+      ...(thirdMetrics.totalSize > 100 * 1024
+        ? [
+            {
+              severity: "warning",
+              message: `Third-party scripts total ${Math.round(thirdMetrics.totalSize / 1024)} KB`,
+            },
+          ]
+        : []),
     ],
   };
 })();
@@ -6566,6 +6621,7 @@ Analyzes font loading strategy by comparing preloaded fonts, loaded fonts, and f
       usedNotPreloadedCount: usedNotPreloaded.length,
     },
     items: uniqueLoadedFonts.map(f => ({ family: f.family, weight: f.weight, style: f.style, display: f.display })),
+  usedFonts: usedFonts.map(f => ({ family: f.family, weight: f.weight, style: f.style, elements: f.elements })),
     issues: [
       ...preloadedNotUsed.map(f => ({ severity: "warning", message: `Preloaded but not used above fold: ${f.name}` })),
       ...usedNotPreloaded.map(f => ({ severity: "warning", message: `Used above fold but not preloaded: ${f.family} (${f.weight})` })),

--- a/skills/webperf-core-web-vitals/references/schema.md
+++ b/skills/webperf-core-web-vitals/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/skills/webperf-interaction/references/schema.md
+++ b/skills/webperf-interaction/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/skills/webperf-loading/references/schema.md
+++ b/skills/webperf-loading/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/skills/webperf-media/references/schema.md
+++ b/skills/webperf-media/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/skills/webperf-resources/references/schema.md
+++ b/skills/webperf-resources/references/schema.md
@@ -85,8 +85,15 @@ Scripts that read DOM or `performance.getEntriesByType()` directly. Return JSON 
   console.log(`TTFB: ${value}ms (${rating})`);
 
   // Agent output
-  return { script: "TTFB", status: "ok", metric: "TTFB", value, unit: "ms", rating,
-           thresholds: { good: 800, needsImprovement: 1800 } };
+  return {
+    script: "TTFB",
+    status: "ok",
+    metric: "TTFB",
+    value,
+    unit: "ms",
+    rating,
+    thresholds: { good: 800, needsImprovement: 1800 },
+  };
 })();
 ```
 
@@ -137,11 +144,12 @@ return {
   script: "INP",
   status: "tracking",
   message: "INP tracking active. Interact with the page then call getINP() for results.",
-  getDataFn: "getINP"
+  getDataFn: "getINP",
 };
 ```
 
 **Agent workflow for tracking scripts:**
+
 ```
 1. evaluate_script(INP.js)          → { status: "tracking", getDataFn: "getINP" }
 2. (user interacts with the page)
@@ -167,6 +175,7 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
 ### Core Web Vitals
 
 #### LCP
+
 ```json
 {
   "script": "LCP",
@@ -179,14 +188,16 @@ Keep the existing `async () => {}` wrapper. Add a `return` statement with struct
   "details": {
     "element": "img.hero",
     "elementType": "Image",
-    "url": "https://example.com/hero.jpg",
+    "url": "https://web.dev/hero.jpg",
     "sizePixels": 756000
   }
 }
 ```
 
 #### CLS
+
 Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` after interactions to get an updated value.
+
 ```json
 {
   "script": "CLS",
@@ -200,9 +211,11 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getCLS"
 }
 ```
+
 `getCLS()` returns the same shape with the latest accumulated value.
 
 #### INP (tracking)
+
 ```json
 {
   "script": "INP",
@@ -211,7 +224,9 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   "getDataFn": "getINP"
 }
 ```
+
 `getINP()` returns:
+
 ```json
 {
   "script": "INP",
@@ -228,17 +243,24 @@ Returns buffered CLS immediately and keeps tracking. Always call `getCLS()` afte
   }
 }
 ```
+
 If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "getINP"` — retry after user interaction.
 
 `getINPDetails()` returns the full sorted interaction list (array of up to 15 entries). Use when `getINP()` shows poor INP and you need to identify patterns across multiple slow interactions:
+
 ```json
 [
-  { "formattedName": "click → button.submit", "duration": 450, "startTime": 1200,
-    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 } }
+  {
+    "formattedName": "click → button.submit",
+    "duration": 450,
+    "startTime": 1200,
+    "phases": { "inputDelay": 120, "processingTime": 280, "presentationDelay": 50 }
+  }
 ]
 ```
 
 #### LCP-Subparts
+
 ```json
 {
   "script": "LCP-Subparts",
@@ -263,6 +285,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### LCP-Trail
+
 ```json
 {
   "script": "LCP-Trail",
@@ -277,13 +300,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "finalElement": "img.hero",
     "candidates": [
       { "index": 1, "selector": "h1", "time": 800, "elementType": "Text block" },
-      { "index": 2, "selector": "img.hero", "time": 1240, "elementType": "Image", "url": "hero.jpg" }
+      {
+        "index": 2,
+        "selector": "img.hero",
+        "time": 1240,
+        "elementType": "Image",
+        "url": "hero.jpg"
+      }
     ]
   }
 }
 ```
 
 #### LCP-Image-Entropy
+
 ```json
 {
   "script": "LCP-Image-Entropy",
@@ -300,13 +330,23 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     }
   },
   "items": [
-    { "url": "hero.jpg", "width": 1200, "height": 630, "fileSizeBytes": 156000, "bpp": 1.65, "isLowEntropy": false, "lcpEligible": true, "isLCP": true }
+    {
+      "url": "hero.jpg",
+      "width": 1200,
+      "height": 630,
+      "fileSizeBytes": 156000,
+      "bpp": 1.65,
+      "isLowEntropy": false,
+      "lcpEligible": true,
+      "isLCP": true
+    }
   ],
   "issues": []
 }
 ```
 
 #### LCP-Video-Candidate
+
 ```json
 {
   "script": "LCP-Video-Candidate",
@@ -318,7 +358,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
   "thresholds": { "good": 2500, "needsImprovement": 4000 },
   "details": {
     "isVideo": true,
-    "posterUrl": "https://example.com/hero.avif",
+    "posterUrl": "https://web.dev/hero.avif",
     "posterFormat": "avif",
     "posterPreloaded": true,
     "fetchpriorityOnPreload": "high",
@@ -332,6 +372,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Loading
 
 #### TTFB
+
 ```json
 {
   "script": "TTFB",
@@ -345,6 +386,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### TTFB-Sub-Parts
+
 ```json
 {
   "script": "TTFB-Sub-Parts",
@@ -369,6 +411,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Find-render-blocking-resources
+
 ```json
 {
   "script": "Find-render-blocking-resources",
@@ -380,12 +423,20 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "byType": { "link": 2, "script": 1 }
   },
   "items": [
-    { "type": "link", "url": "https://example.com/style.css", "shortName": "style.css", "responseEndMs": 450, "durationMs": 200, "sizeBytes": 45000 }
+    {
+      "type": "link",
+      "url": "https://web.dev/style.css",
+      "shortName": "style.css",
+      "responseEndMs": 450,
+      "durationMs": 200,
+      "sizeBytes": 45000
+    }
   ]
 }
 ```
 
 #### Script-Loading
+
 ```json
 {
   "script": "Script-Loading",
@@ -399,7 +450,15 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
     "thirdPartyBlockingCount": 1
   },
   "items": [
-    { "url": "https://example.com/app.js", "shortName": "app.js", "strategy": "blocking", "location": "head", "party": "first", "sizeBytes": 85000, "durationMs": 120 }
+    {
+      "url": "https://web.dev/app.js",
+      "shortName": "app.js",
+      "strategy": "blocking",
+      "location": "head",
+      "party": "first",
+      "sizeBytes": 85000,
+      "durationMs": 120
+    }
   ],
   "issues": [
     { "severity": "error", "message": "2 blocking scripts in <head>" },
@@ -411,6 +470,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ### Interaction
 
 #### Interactions (tracking)
+
 ```json
 {
   "script": "Interactions",
@@ -421,6 +481,7 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Input-Latency-Breakdown (tracking)
+
 ```json
 {
   "script": "Input-Latency-Breakdown",
@@ -431,7 +492,9 @@ If no interactions yet, `getINP()` returns `status: "error"` with `getDataFn: "g
 ```
 
 #### Layout-Shift-Loading-and-Interaction
+
 Immediately returns buffered CLS data, plus exposes summary function for ongoing tracking.
+
 ```json
 {
   "script": "Layout-Shift-Loading-and-Interaction",
@@ -453,7 +516,9 @@ Immediately returns buffered CLS data, plus exposes summary function for ongoing
 ```
 
 #### Long-Animation-Frames
+
 Returns buffered LoAF data immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "Long-Animation-Frames",
@@ -471,7 +536,9 @@ Returns buffered LoAF data immediately. Ongoing tracking continues.
 ```
 
 #### Long-Animation-Frames-Script-Attribution
+
 Returns buffered LoAF data immediately (do not wait for a timer):
+
 ```json
 {
   "script": "Long-Animation-Frames-Script-Attribution",
@@ -485,13 +552,12 @@ Returns buffered LoAF data immediately (do not wait for a timer):
       "framework": { "durationMs": 30, "count": 1 }
     }
   },
-  "items": [
-    { "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }
-  ]
+  "items": [{ "file": "app.js", "category": "first-party", "durationMs": 180, "count": 3 }]
 }
 ```
 
 #### Scroll-Performance (tracking)
+
 ```json
 {
   "script": "Scroll-Performance",
@@ -510,7 +576,9 @@ Returns buffered LoAF data immediately (do not wait for a timer):
 ```
 
 #### LongTask
+
 Returns buffered long tasks immediately. Ongoing tracking continues.
+
 ```json
 {
   "script": "LongTask",
@@ -529,6 +597,7 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
 ### Media
 
 #### Image-Element-Audit (async)
+
 ```json
 {
   "script": "Image-Element-Audit",
@@ -567,32 +636,34 @@ Returns buffered long tasks immediately. Ongoing tracking continues.
     }
   ],
   "issues": [
-    { "severity": "warning", "message": "img.thumbnail: Missing width/height attributes (CLS risk)" }
+    {
+      "severity": "warning",
+      "message": "img.thumbnail: Missing width/height attributes (CLS risk)"
+    }
   ]
 }
 ```
 
 #### Video-Element-Audit
+
 Same shape as Image-Element-Audit but for video elements.
 
 #### SVG-Embedded-Bitmap-Analysis
+
 ```json
 {
   "script": "SVG-Embedded-Bitmap-Analysis",
   "status": "ok",
   "count": 2,
-  "items": [
-    { "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }
-  ],
-  "issues": [
-    { "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }
-  ]
+  "items": [{ "url": "icon.svg", "hasBitmap": true, "bitmapType": "image/png", "sizeBytes": 4500 }],
+  "issues": [{ "severity": "warning", "message": "2 SVG files contain embedded bitmaps" }]
 }
 ```
 
 ### Resources
 
 #### Network-Bandwidth-Connection-Quality
+
 ```json
 {
   "script": "Network-Bandwidth-Connection-Quality",

--- a/snippets/Loading/Find-render-blocking-resources.js
+++ b/snippets/Loading/Find-render-blocking-resources.js
@@ -154,5 +154,8 @@
       durationMs: Math.round(r.duration),
       sizeBytes: r.size,
     })),
+    issues: blockingResources.length > 0
+      ? [{ severity: "error", message: `${blockingResources.length} render-blocking resource(s) delay rendering until ${Math.round(lastBlockingEnd)}ms` }]
+      : [],
   };
 })();

--- a/snippets/Loading/Find-render-blocking-resources.js
+++ b/snippets/Loading/Find-render-blocking-resources.js
@@ -31,6 +31,15 @@
     })
     .sort((a, b) => b.responseEnd - a.responseEnd);
 
+  const lastBlockingEnd = blockingResources.length
+    ? Math.max(...blockingResources.map((r) => r.responseEnd))
+    : 0;
+  const totalSizeBytes = blockingResources.reduce((sum, r) => sum + r.size, 0);
+  const byType = blockingResources.reduce((acc, r) => {
+    acc[r.type] = (acc[r.type] || 0) + 1;
+    return acc;
+  }, {});
+
   console.group("%c🚧 Render-Blocking Resources", "font-weight: bold; font-size: 14px;");
 
   if (blockingResources.length === 0) {
@@ -45,14 +54,6 @@
     console.log("   • Scripts use async or defer attributes");
     console.log("   • Critical resources are optimized");
   } else {
-    // Calculate metrics
-    const lastBlockingEnd = Math.max(...blockingResources.map((r) => r.responseEnd));
-    const totalSize = blockingResources.reduce((sum, r) => sum + r.size, 0);
-    const byType = blockingResources.reduce((acc, r) => {
-      acc[r.type] = (acc[r.type] || 0) + 1;
-      return acc;
-    }, {});
-
     // Summary
     console.log(
       `%c⚠️ Found ${blockingResources.length} render-blocking resource(s)`,
@@ -63,8 +64,8 @@
     console.log("%c📊 Impact Summary:", "font-weight: bold;");
     console.log(`   Rendering blocked until: ${lastBlockingEnd.toFixed(0)}ms`);
     console.log(`   Total blocking resources: ${blockingResources.length}`);
-    if (totalSize > 0) {
-      const sizeKB = (totalSize / 1024).toFixed(1);
+    if (totalSizeBytes > 0) {
+      const sizeKB = (totalSizeBytes / 1024).toFixed(1);
       console.log(`   Total size: ${sizeKB} KB`);
     }
     console.log(`   By type: ${Object.entries(byType).map(([k, v]) => `${k} (${v})`).join(", ")}`);
@@ -134,9 +135,6 @@
 
   console.groupEnd();
 
-  const lastBlockingEnd = blockingResources.length ? Math.max(...blockingResources.map((r) => r.responseEnd)) : 0;
-  const totalSizeBytes = blockingResources.reduce((sum, r) => sum + r.size, 0);
-  const byType = blockingResources.reduce((acc, r) => { acc[r.type] = (acc[r.type] || 0) + 1; return acc; }, {});
   return {
     script: "Find-render-blocking-resources",
     status: "ok",

--- a/snippets/Loading/First-And-Third-Party-Script-Info.js
+++ b/snippets/Loading/First-And-Third-Party-Script-Info.js
@@ -67,10 +67,14 @@
   const firstMetrics = calcMetrics(firstParty);
   const thirdMetrics = calcMetrics(thirdParty);
   const totalScripts = scripts.length;
-  const thirdPartyPct = totalScripts > 0 ? ((thirdParty.length / totalScripts) * 100).toFixed(0) : 0;
+  const thirdPartyPct =
+    totalScripts > 0 ? ((thirdParty.length / totalScripts) * 100).toFixed(0) : 0;
 
   // Display results
-  console.group("%c📊 Script Analysis: First vs Third Party", "font-weight: bold; font-size: 14px;");
+  console.group(
+    "%c📊 Script Analysis: First vs Third Party",
+    "font-weight: bold; font-size: 14px;",
+  );
 
   // Overall summary
   console.log("");
@@ -85,7 +89,10 @@
 
   // First Party Section
   console.log("");
-  console.group(`%c🏠 First-Party Scripts (${firstParty.length})`, "color: #22c55e; font-weight: bold;");
+  console.group(
+    `%c🏠 First-Party Scripts (${firstParty.length})`,
+    "color: #22c55e; font-weight: bold;",
+  );
 
   if (firstParty.length === 0) {
     console.log("No first-party scripts found.");
@@ -109,13 +116,13 @@
 
   // Third Party Section
   console.log("");
-  console.group(`%c🌐 Third-Party Scripts (${thirdParty.length})`, "color: #ef4444; font-weight: bold;");
+  console.group(
+    `%c🌐 Third-Party Scripts (${thirdParty.length})`,
+    "color: #ef4444; font-weight: bold;",
+  );
 
   if (thirdParty.length === 0) {
-    console.log(
-      "%c✅ No third-party scripts found!",
-      "color: #22c55e; font-weight: bold;"
-    );
+    console.log("%c✅ No third-party scripts found!", "color: #22c55e; font-weight: bold;");
   } else {
     console.log(`   Total size: ${formatBytes(thirdMetrics.totalSize)}`);
     console.log(`   Render-blocking: ${thirdMetrics.blocking}`);
@@ -136,7 +143,9 @@
       .sort((a, b) => b[1].size - a[1].size)
       .forEach(([host, data]) => {
         const blockingMark = data.blocking > 0 ? " ⚠️" : "";
-        console.log(`      ${host}: ${data.count} script(s), ${formatBytes(data.size)}${blockingMark}`);
+        console.log(
+          `      ${host}: ${data.count} script(s), ${formatBytes(data.size)}${blockingMark}`,
+        );
       });
 
     console.log("");
@@ -160,23 +169,38 @@
 
     if (thirdMetrics.blocking > 0) {
       console.log("");
-      console.log("%c⚠️ Render-blocking third-party scripts:", "font-weight: bold; color: #ef4444;");
+      console.log(
+        "%c⚠️ Render-blocking third-party scripts:",
+        "font-weight: bold; color: #ef4444;",
+      );
       console.log("   • Load with 'async' or 'defer' attribute");
       console.log("   • Consider lazy-loading after user interaction");
-      console.log('%c   <script src="..." async></script>', "font-family: monospace; color: #22c55e;");
+      console.log(
+        '%c   <script src="..." async></script>',
+        "font-family: monospace; color: #22c55e;",
+      );
     }
 
     if (thirdMetrics.hosts.length > 3) {
       console.log("");
-      console.log(`%c⚠️ ${thirdMetrics.hosts.length} different third-party hosts:`, "font-weight: bold; color: #f59e0b;");
+      console.log(
+        `%c⚠️ ${thirdMetrics.hosts.length} different third-party hosts:`,
+        "font-weight: bold; color: #f59e0b;",
+      );
       console.log("   • Each host requires DNS lookup + connection");
       console.log("   • Use <link rel='preconnect'> for critical hosts");
-      console.log('%c   <link rel="preconnect" href="https://example.com">', "font-family: monospace; color: #22c55e;");
+      console.log(
+        '%c   <link rel="preconnect" href="https://web.dev">',
+        "font-family: monospace; color: #22c55e;",
+      );
     }
 
     if (thirdMetrics.totalSize > 100 * 1024) {
       console.log("");
-      console.log(`%c⚠️ Third-party scripts total ${formatBytes(thirdMetrics.totalSize)}:`, "font-weight: bold; color: #f59e0b;");
+      console.log(
+        `%c⚠️ Third-party scripts total ${formatBytes(thirdMetrics.totalSize)}:`,
+        "font-weight: bold; color: #f59e0b;",
+      );
       console.log("   • Audit necessity of each script");
       console.log("   • Consider self-hosting critical scripts");
       console.log("   • Look for lighter alternatives");
@@ -207,11 +231,39 @@
       thirdPartyBlockingCount: thirdMetrics.blocking,
       thirdPartyHostCount: thirdMetrics.hosts.length,
     },
-    items: scripts.map(s => ({ shortName: s.shortName, host: s.host, firstParty: s.firstParty, transferBytes: s.transferSize, durationMs: Math.round(s.duration), renderBlocking: s.renderBlocking })),
+    items: scripts.map((s) => ({
+      shortName: s.shortName,
+      host: s.host,
+      firstParty: s.firstParty,
+      transferBytes: s.transferSize,
+      durationMs: Math.round(s.duration),
+      renderBlocking: s.renderBlocking,
+    })),
     issues: [
-      ...(thirdMetrics.blocking > 0 ? [{ severity: "error", message: `${thirdMetrics.blocking} render-blocking third-party script(s)` }] : []),
-      ...(thirdMetrics.hosts.length > 3 ? [{ severity: "warning", message: `${thirdMetrics.hosts.length} different third-party hosts require separate DNS lookups` }] : []),
-      ...(thirdMetrics.totalSize > 100 * 1024 ? [{ severity: "warning", message: `Third-party scripts total ${Math.round(thirdMetrics.totalSize / 1024)} KB` }] : []),
+      ...(thirdMetrics.blocking > 0
+        ? [
+            {
+              severity: "error",
+              message: `${thirdMetrics.blocking} render-blocking third-party script(s)`,
+            },
+          ]
+        : []),
+      ...(thirdMetrics.hosts.length > 3
+        ? [
+            {
+              severity: "warning",
+              message: `${thirdMetrics.hosts.length} different third-party hosts require separate DNS lookups`,
+            },
+          ]
+        : []),
+      ...(thirdMetrics.totalSize > 100 * 1024
+        ? [
+            {
+              severity: "warning",
+              message: `Third-party scripts total ${Math.round(thirdMetrics.totalSize / 1024)} KB`,
+            },
+          ]
+        : []),
     ],
   };
 })();

--- a/snippets/Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold.js
+++ b/snippets/Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold.js
@@ -307,6 +307,7 @@
       usedNotPreloadedCount: usedNotPreloaded.length,
     },
     items: uniqueLoadedFonts.map(f => ({ family: f.family, weight: f.weight, style: f.style, display: f.display })),
+  usedFonts: usedFonts.map(f => ({ family: f.family, weight: f.weight, style: f.style, elements: f.elements })),
     issues: [
       ...preloadedNotUsed.map(f => ({ severity: "warning", message: `Preloaded but not used above fold: ${f.name}` })),
       ...usedNotPreloaded.map(f => ({ severity: "warning", message: `Used above fold but not preloaded: ${f.family} (${f.weight})` })),


### PR DESCRIPTION
## Summary

- Adds a headless CLI (`webperf-snippets`) that runs curated WebPerf Snippets via Playwright, enabling Core Web Vitals diagnosis and structural audits in CI without manual DevTools copy-paste.
- Root package renamed to `webperf-snippets-docs` (private, no external impact); `cli/` added as npm workspace with `name: webperf-snippets`.
- Zero non-peer deps — only requires Node ≥ 20.12 and Playwright as a peer dependency.

## Available snippets

| Alias | Snippet | Category |
|---|---|---|
| `LCP` | Largest Contentful Paint | Core Web Vitals |
| `CLS` | Cumulative Layout Shift | Core Web Vitals |
| `LCP-Subparts` | LCP Subparts breakdown | Core Web Vitals |
| `fonts` | Fonts Preloaded, Loaded, and Used Above The Fold | Loading |
| `render-blocking` | Find render-blocking resources | Loading |
| `resource-hints` | Resource Hints Validation | Loading |
| `preload-scripts` | Validate Preload / Async / Defer Scripts | Loading |
| `priority-hints` | Priority Hints Audit | Loading |
| `critical-css` | Critical CSS Detection | Loading |
| `ttfb` | TTFB Sub-Parts | Loading |
| `script-parties` | First and Third-Party Script Info | Loading |
| `script-loading` | Script Loading | Loading |
| `lazy-atf` | Above-the-fold lazy-loaded images | Loading |
| `lazy-conflict` | Images with `lazy` + `fetchpriority` conflict | Loading |
| `eager-below-fold` | Non-lazy images outside viewport | Loading |

## Workflows

Two built-in workflows selectable via `--workflow`:

- **`core-web-vitals`** (default) — runs `LCP` + `CLS`, auto-enqueues `LCP-Subparts` if LCP exceeds 2.5 s.
- **`audit`** — deterministic structural checks (no timing noise) covering all Tier 1 Loading and Media snippets; designed for CI pass/fail gating.

## Usage

```bash
# Default workflow: LCP + CLS, auto-enqueues LCP-Subparts if LCP > 2.5 s
npx webperf-snippets https://example.com

# Structural audit — deterministic, CI-friendly
npx webperf-snippets https://example.com --workflow audit

# JSON output for CI pipes
npx webperf-snippets https://example.com --json

# Single snippet by alias
npx webperf-snippets https://example.com --snippet LCP-Subparts
npx webperf-snippets https://example.com --snippet render-blocking

# Viewport preset (mobile default)
npx webperf-snippets https://example.com --viewport desktop

# Show all items, even passing checks
npx webperf-snippets https://example.com --verbose

# Budget gating — exits 1 on violation
npx webperf-snippets https://example.com --budget-lcp 2500 --budget-cls 0.1
```

## Files added / changed

| File | Purpose |
|---|---|
| `cli/package.json` | Package config, bin, peer dep |
| `cli/src/bin.js` | CLI entry, `util.parseArgs`, exit codes 0/1/2 |
| `cli/src/runner.js` | Playwright launch, snippet evaluator |
| `cli/src/load-snippet.js` | Resolves snippets by alias or `Category/Name` path |
| `cli/src/workflows/cwv.js` | Core Web Vitals workflow |
| `cli/src/workflows/audit.js` | Structural audit workflow (Tier 1 + Tier 2 snippets) |
| `cli/src/decision-tree.js` | Declarative follow-up rules |
| `cli/src/reporters/human.js` | Colour table via `util.styleText` |
| `cli/src/reporters/json.js` | Raw JSON output |
| `cli/tests/unit/` | Vitest unit tests (reporters, decision-tree, viewport presets) |
| `cli/tests/e2e/` | Vitest E2E tests against local HTML fixtures (CWV + audit workflows) |
| `cli/tests/fixtures/` | Minimal HTML pages for deterministic E2E runs |
| `cli/README.md` | Usage, options, CI example, known limitations |
| `pages/CLI.mdx` | CLI documentation page on the site |
| `.github/workflows/ci.yml` | Unit + E2E tests added to CI |
| `.github/workflows/publish-cli.yml` | Automated npm publish on release tag |

## Test plan

- [x] `node cli/src/bin.js --help` prints usage
- [x] `node cli/src/bin.js https://web.dev` returns green LCP + CLS with element info
- [x] `node cli/src/bin.js https://web.dev --workflow audit` runs all structural checks
- [x] `node cli/src/bin.js https://web.dev --json` returns valid JSON with all fields
- [x] `node cli/src/bin.js https://web.dev --snippet LCP-Subparts` shows sub-part breakdown
- [x] `node cli/src/bin.js https://web.dev --snippet render-blocking` shows blocking resources
- [x] `node cli/src/bin.js https://web.dev --snippet fonts` shows loaded/used-above-fold font tables
- [x] `node cli/src/bin.js https://web.dev --viewport desktop` runs at desktop viewport
- [x] `node cli/src/bin.js https://web.dev --budget-lcp 100` exits 1 with violation on stderr
- [x] `node cli/src/bin.js https://web.dev --verbose` shows all items including passing checks
- [x] Vitest unit + E2E suite passes (`npm test` in `cli/`)
- [x] CI pipeline runs tests on every push