### PR TITLE
fix: use buffered observer in agent return path for LCP and CLS snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A curated collection of JavaScript snippets to measure and debug Web Performance
 
 [![CI](https://github.com/nucliweb/webperf-snippets/actions/workflows/ci.yml/badge.svg)](https://github.com/nucliweb/webperf-snippets/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/nucliweb/webperf-snippets)](https://github.com/nucliweb/webperf-snippets/releases)
-[![Snippets](https://img.shields.io/badge/snippets-48-0f766e)](https://webperf-snippets.nucliweb.net)
+[![Snippets](https://img.shields.io/badge/snippets-49-0f766e)](https://webperf-snippets.nucliweb.net)
 [![License](https://img.shields.io/github/license/nucliweb/webperf-snippets)](./LICENSE)
 [![Star History](https://img.shields.io/github/stars/nucliweb/webperf-snippets?style=social)](https://star-history.com/#nucliweb/webperf-snippets&Date)
 
@@ -87,7 +87,7 @@ This installs skills to `~/.claude/skills/` for use across any project.
 
 | Skill                     | Snippets | Description                                                      |
 | ------------------------- | -------- | ---------------------------------------------------------------- |
-| `webperf`                 | 48       | Main entry point for all web performance analysis                |
+| `webperf`                 | 49       | Main entry point for all web performance analysis                |
 | `webperf-core-web-vitals` | 7        | LCP, CLS, INP measurements with detailed breakdowns              |
 | `webperf-loading`         | 29       | TTFB, FCP, script/font analysis, resource hints, service workers |
 | `webperf-interaction`     | 8        | Long tasks, animation frames, scroll jank, INP debugging         |

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -6,7 +6,7 @@ A collection of [Agent Skills](https://agentskills.io/) for measuring and debugg
 
 ## Why WebPerf Skills?
 
-These skills transform 48 battle-tested JavaScript snippets into agent capabilities for any skills-compatible AI coding assistant:
+These skills transform 49 battle-tested JavaScript snippets into agent capabilities for any skills-compatible AI coding assistant:
 
 - **Browser Console Integration**: Run performance measurements directly in Chrome DevTools
 - **Real-time Analysis**: Measure actual user experience on live pages
@@ -105,7 +105,7 @@ The main entry point that helps identify the right skill for your performance qu
 **What it does:**
 
 - Routes to the appropriate specialized skill
-- Provides overview of all 48 available snippets
+- Provides overview of all 49 available snippets
 - Suggests which skill to use based on your question
 
 ### webperf-core-web-vitals

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,8 +73,10 @@ const browserGlobals = {
   encodeURIComponent: "readonly",
   caches: "readonly",
   CSSRule: "readonly",
+  CSSStyleDeclaration: "readonly",
   NodeFilter: "readonly",
   EventTarget: "readonly",
+  DOMTokenList: "readonly",
 };
 
 export default [

--- a/skills/webperf/SKILL.md
+++ b/skills/webperf/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # WebPerf Snippets Toolkit
 
-A collection of 48 JavaScript snippets for measuring and debugging web performance in Chrome DevTools. Each snippet runs in the browser console and outputs structured, color-coded results.
+A collection of 49 JavaScript snippets for measuring and debugging web performance in Chrome DevTools. Each snippet runs in the browser console and outputs structured, color-coded results.
 
 ## Quick Reference
 

--- a/snippets/CoreWebVitals/CLS.js
+++ b/snippets/CoreWebVitals/CLS.js
@@ -1,7 +1,7 @@
 // CLS Quick Check
 // https://webperf-snippets.nucliweb.net
 
-(() => {
+(async () => {
   let cls = 0;
 
   const valueToRating = (score) =>
@@ -63,9 +63,16 @@
     ""
   );
 
-  // Synchronous return for agent (buffered entries)
-  const clsSync = performance.getEntriesByType("layout-shift")
-    .reduce((sum, e) => !e.hadRecentInput ? sum + e.value : sum, 0);
+  // Return for agent — collect via buffered observer (getEntriesByType does not
+  // expose layout-shift entries in Chrome without an active observer).
+  const clsSync = await new Promise((resolve) => {
+    let sum = 0;
+    const obs = new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) if (!e.hadRecentInput) sum += e.value;
+    });
+    obs.observe({ type: "layout-shift", buffered: true });
+    setTimeout(() => { obs.disconnect(); resolve(sum); }, 0);
+  });
   const clsRating = valueToRating(clsSync);
   return {
     script: "CLS",

--- a/snippets/CoreWebVitals/LCP-Sub-Parts.js
+++ b/snippets/CoreWebVitals/LCP-Sub-Parts.js
@@ -1,7 +1,7 @@
 // LCP Sub-Parts Analysis
 // https://webperf-snippets.nucliweb.net
 
-(() => {
+(async () => {
   const formatMs = (ms) => `${Math.round(ms)}ms`;
   const formatPercent = (value, total) => `${Math.round((value / total) * 100)}%`;
 
@@ -204,11 +204,16 @@
   console.log("%c📊 LCP Sub-Parts Analysis Active", "font-weight: bold; font-size: 14px;");
   console.log("   Waiting for LCP...");
 
-  // Synchronous return for agent (buffered entries)
-  const lcpBuffered = performance.getEntriesByType("largest-contentful-paint");
-  const lcpEntry = lcpBuffered.at(-1);
+  // Return for agent — collect via buffered observer (getEntriesByType does not
+  // expose largest-contentful-paint entries in Chrome without an active observer).
+  const lcpEntry = await new Promise((resolve) => {
+    const entries = [];
+    const obs = new PerformanceObserver((list) => entries.push(...list.getEntries()));
+    obs.observe({ type: "largest-contentful-paint", buffered: true });
+    setTimeout(() => { obs.disconnect(); resolve(entries.at(-1) ?? null); }, 0);
+  });
   if (!lcpEntry) {
-    return { script: "LCP-Sub-Parts", status: "error", error: "No LCP entries yet" };
+    return { script: "LCP-Sub-Parts", status: "error", error: "No LCP entries buffered" };
   }
   const navEntrySync = getNavigationEntry();
   if (!navEntrySync) {

--- a/snippets/CoreWebVitals/LCP.js
+++ b/snippets/CoreWebVitals/LCP.js
@@ -1,7 +1,7 @@
 // LCP Quick Check
 // https://webperf-snippets.nucliweb.net
 
-(() => {
+(async () => {
   const valueToRating = (ms) =>
     ms <= 2500 ? "good" : ms <= 4000 ? "needs-improvement" : "poor";
 
@@ -83,11 +83,16 @@
   console.log("%c⏱️ LCP Tracking Active", "font-weight: bold; font-size: 14px;");
   console.log("   LCP may update as larger elements load.");
 
-  // Synchronous return for agent (buffered entries)
-  const lcpEntries = performance.getEntriesByType("largest-contentful-paint");
-  const lastLcpEntry = lcpEntries.at(-1);
+  // Return for agent — collect via buffered observer (getEntriesByType does not
+  // expose largest-contentful-paint entries in Chrome without an active observer).
+  const lastLcpEntry = await new Promise((resolve) => {
+    const entries = [];
+    const obs = new PerformanceObserver((list) => entries.push(...list.getEntries()));
+    obs.observe({ type: "largest-contentful-paint", buffered: true });
+    setTimeout(() => { obs.disconnect(); resolve(entries.at(-1) ?? null); }, 0);
+  });
   if (!lastLcpEntry) {
-    return { script: "LCP", status: "error", error: "No LCP entries yet" };
+    return { script: "LCP", status: "error", error: "No LCP entries buffered" };
   }
   const lcpActivationStart = getActivationStart();
   const lcpValue = Math.round(Math.max(0, lastLcpEntry.startTime - lcpActivationStart));


### PR DESCRIPTION
## Finding

`performance.getEntriesByType("largest-contentful-paint")` and `"layout-shift"` **always return an empty array** in Chrome unless a `PerformanceObserver` has been actively subscribed. This is a Chrome implementation detail: these entry types are observer-only and are not written to the shared performance timeline buffer.

### Impact

The "Synchronous return for agent" section at the bottom of these snippets was silently returning `{ status: "error", error: "No LCP entries yet" }` in every automated context:

- **Chrome DevTools MCP** (`mcp__chrome-devtools__evaluate_script`)
- **WebPerf Skills via CDP**
- **The new CLI** (discovered during CLI development — the CLI works around it via an `addInitScript` shim, but the root cause is in the snippets)

Manual DevTools console usage was not affected because the preceding observer registration happens to populate a context-local buffer that the synchronous read can sometimes see on long-lived pages, but this was never reliable.

### Verification

```js
// Chrome returns [] for these, even after observer.observe({ buffered: true }):
performance.getEntriesByType("largest-contentful-paint") // []
performance.getEntriesByType("layout-shift")             // []

// Only a PerformanceObserver callback delivers the entries:
new PerformanceObserver((list) => list.getEntries()) // ✓ entries here
  .observe({ type: "largest-contentful-paint", buffered: true });
```

## Fix

- Changed `(() => {` → `(async () => {` in the 3 affected snippets.
- Replaced `getEntriesByType` with a short-lived `PerformanceObserver` that resolves after `setTimeout(0)` (guarantees all buffered microtasks have flushed).
- **Chrome DevTools console is unaffected**: modern Chrome auto-awaits async IIFEs and displays the resolved value inline.
- **`page.evaluate()` (Playwright/CDP) is unaffected**: it already awaits Promises.

## Affected snippets

| Snippet | Entry type fixed |
|---|---|
| `LCP.js` | `largest-contentful-paint` |
| `CLS.js` | `layout-shift` |
| `LCP-Sub-Parts.js` | `largest-contentful-paint` |

> `"resource"` and `"navigation"` entries used in `LCP-Sub-Parts.js` work correctly via `getEntriesByType` and are unchanged.

## Test plan

- [ ] Run `LCP.js` via Chrome DevTools MCP `evaluate_script` on a live page — result should be `{ status: "ok", value: <ms>, ... }` not `{ status: "error" }`.
- [ ] Same for `CLS.js` and `LCP-Sub-Parts.js`.
- [ ] Run each snippet interactively in Chrome DevTools console — should display the resolved object (Chrome auto-awaits).
- [ ] Confirm `LCP-Video-Candidate.js` is unaffected (it already used a proper observer pattern).