### PR TITLE
feat: auto-capture snippet console outputs at build time

### DIFF
--- a/components/Snippet.jsx
+++ b/components/Snippet.jsx
@@ -1,14 +1,17 @@
+import javascript from "highlight.js/lib/languages/javascript";
 import { useState, useMemo } from "react";
 import hljs from "highlight.js/lib/core";
-import javascript from "highlight.js/lib/languages/javascript";
 
 hljs.registerLanguage("javascript", javascript);
 
-export function Snippet({ code }) {
+export function Snippet({ code, output }) {
   const [copied, setCopied] = useState(false);
   const [hovered, setHovered] = useState(false);
 
-  const highlighted = useMemo(() => hljs.highlight(code, { language: "javascript" }).value, [code]);
+  const highlighted = useMemo(
+    () => hljs.highlight(code, { language: "javascript" }).value,
+    [code],
+  );
 
   async function handleCopy() {
     try {
@@ -27,58 +30,72 @@ export function Snippet({ code }) {
   }
 
   return (
-    <div
-      className="nextra-code-block nx-relative nx-mt-6 first:nx-mt-0"
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-    >
-      <pre
-        data-language="js"
-        data-theme="default"
-        className="nx-bg-primary-700/5 nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-subpixel-antialiased dark:nx-bg-primary-300/10 nx-text-[13px] contrast-more:nx-border contrast-more:nx-border-primary-900/20 contrast-more:nx-contrast-150 contrast-more:dark:nx-border-primary-100/40"
+    <div className="nextra-code-block nx-relative nx-mt-6 first:nx-mt-0">
+      {/* Code block */}
+      <div
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="nx-relative"
       >
-        <code
+        <pre
           data-language="js"
           data-theme="default"
-          className="hljs nx-border-black nx-border-opacity-[0.04] nx-bg-opacity-[0.03] nx-bg-black nx-break-words nx-rounded-md nx-border dark:nx-border-white/10 dark:nx-bg-white/10 nx-py-4 nx-px-4"
-          dangerouslySetInnerHTML={{ __html: highlighted }}
-        />
-      </pre>
-      <div
-        className="nx-transition nx-flex nx-gap-1 nx-absolute nx-m-[11px] nx-right-0 nx-top-0"
-        style={{ opacity: hovered || copied ? 1 : 0 }}
-      >
-        <button
-          onClick={handleCopy}
-          aria-label="Copy code"
-          className="nextra-button nx-transition-all active:nx-opacity-50 nx-bg-primary-700/5 nx-border nx-border-black/5 nx-text-gray-600 hover:nx-text-gray-900 nx-rounded-md nx-p-1.5 dark:nx-bg-gray-100/5 dark:nx-border-white/10 dark:nx-text-gray-400 dark:hover:nx-text-gray-50"
+          className="nx-bg-primary-700/5 nx-mb-4 nx-overflow-x-auto nx-rounded-xl nx-subpixel-antialiased dark:nx-bg-primary-300/10 nx-text-[13px] contrast-more:nx-border contrast-more:nx-border-primary-900/20 contrast-more:nx-contrast-150 contrast-more:dark:nx-border-primary-100/40"
         >
-          {copied ? (
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          ) : (
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-            >
-              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-            </svg>
-          )}
-        </button>
+          <code
+            data-language="js"
+            data-theme="default"
+            className="hljs nx-border-black nx-border-opacity-[0.04] nx-bg-opacity-[0.03] nx-bg-black nx-break-words nx-rounded-md nx-border dark:nx-border-white/10 dark:nx-bg-white/10 nx-py-4 nx-px-4"
+            dangerouslySetInnerHTML={{ __html: highlighted }}
+          />
+        </pre>
+        <div
+          className="nx-transition nx-flex nx-gap-1 nx-absolute nx-m-[11px] nx-right-0 nx-top-0"
+          style={{ opacity: hovered || copied ? 1 : 0 }}
+        >
+          <button
+            onClick={handleCopy}
+            aria-label="Copy code"
+            className="nextra-button nx-transition-all active:nx-opacity-50 nx-bg-primary-700/5 nx-border nx-border-black/5 nx-text-gray-600 hover:nx-text-gray-900 nx-rounded-md nx-p-1.5 dark:nx-bg-gray-100/5 dark:nx-border-white/10 dark:nx-text-gray-400 dark:hover:nx-text-gray-50"
+          >
+            {copied ? (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            ) : (
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+              </svg>
+            )}
+          </button>
+        </div>
       </div>
+
+      {output && (
+        <div className="nx-mt-2 nx-mb-4">
+          <p className="nx-text-xs nx-font-semibold nx-text-gray-500 dark:nx-text-gray-400 nx-mb-1 nx-uppercase nx-tracking-wide">
+            Expected Output
+          </p>
+          <pre className="nx-bg-gray-50 dark:nx-bg-gray-900 nx-rounded-xl nx-border nx-border-black/5 dark:nx-border-white/10 nx-overflow-x-auto nx-text-[13px] nx-p-4 nx-text-gray-700 dark:nx-text-gray-300">
+            {output}
+          </pre>
+        </div>
+      )}
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "eslint": "^10.0.2",
+        "playwright": "^1.59.1",
         "terser": "^5.36.0",
         "vercel": "^32.4.1"
       }
@@ -14065,6 +14066,53 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "dev": "next dev",
     "build": "next build",
     "postbuild": "next-sitemap",
-    "prebuild": "rm -rf .next && node scripts/generate-llms.js",
+    "prebuild": "rm -rf .next && node scripts/generate-llms.js && node scripts/capture-outputs.js && node scripts/inject-outputs.js",
     "check:consistency": "node scripts/check-consistency.js",
     "generate-skills": "node scripts/generate-skills.js",
+    "inject-outputs": "node scripts/inject-outputs.js",
+    "capture-outputs": "node scripts/capture-outputs.js",
     "generate-skills:check": "node scripts/generate-skills.js && git diff --exit-code -- skills dist",
     "install-skills": "node scripts/install-skills.js",
     "install-global": "node scripts/install-global.js",
@@ -38,6 +40,7 @@
   },
   "devDependencies": {
     "eslint": "^10.0.2",
+    "playwright": "^1.59.1",
     "terser": "^5.36.0",
     "vercel": "^32.4.1"
   },

--- a/pages/CoreWebVitals/CLS.mdx
+++ b/pages/CoreWebVitals/CLS.mdx
@@ -23,7 +23,7 @@ Unexpected layout shifts are frustrating and can cause users to click the wrong 
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`Call getCLS() anytime to check current value.`} />
 
 ### Understanding CLS
 

--- a/pages/CoreWebVitals/INP.mdx
+++ b/pages/CoreWebVitals/INP.mdx
@@ -58,7 +58,10 @@ flowchart TD
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⚡ INP Tracking Active
+Interactions with duration > 16ms will be tracked.
+Call getINP() to see current INP value.
+Call getINPDetails() for full interaction list.`} />
 
 ### Understanding INP
 

--- a/pages/CoreWebVitals/LCP-Image-Entropy.mdx
+++ b/pages/CoreWebVitals/LCP-Image-Entropy.mdx
@@ -27,7 +27,11 @@ BPP = (file size in bits) / (width × height)
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`Deprecated API for given entry type.
+🖼️ Image Entropy Analysis
+No images with measurable entropy found.
+(Data URLs and cross-origin images without CORS are excluded)
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/CoreWebVitals/LCP-Subparts.mdx
+++ b/pages/CoreWebVitals/LCP-Subparts.mdx
@@ -48,7 +48,8 @@ flowchart LR
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📊 LCP Subparts Analysis Active
+Waiting for LCP...`} />
 
 ### Understanding the Results
 

--- a/pages/CoreWebVitals/LCP-Trail.mdx
+++ b/pages/CoreWebVitals/LCP-Trail.mdx
@@ -13,7 +13,9 @@ Each time the browser promotes a larger element as the new LCP, the snippet assi
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⏱️ LCP Trail Active
+Highlights all LCP candidate elements with distinct colors.
+Deprecated API for given entry type.`} />
 
 ### How It Works
 

--- a/pages/CoreWebVitals/LCP-Video-Candidate.mdx
+++ b/pages/CoreWebVitals/LCP-Video-Candidate.mdx
@@ -51,7 +51,8 @@ A `<link rel="preload">` in `<head>` shortcuts this chain, allowing the browser 
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`Deprecated API for given entry type.
+⚠️ No LCP entries found. Run this snippet before interacting with the page, or reload and run it immediately.`} />
 
 ### Understanding the Results
 

--- a/pages/CoreWebVitals/LCP.mdx
+++ b/pages/CoreWebVitals/LCP.mdx
@@ -17,7 +17,8 @@ Quick check for [Largest Contentful Paint](https://web.dev/articles/lcp), a Core
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⏱️ LCP Tracking Active
+LCP may update as larger elements load.`} />
 
 ### Understanding LCP
 

--- a/pages/DevTools-Overrides/Fetch-XHR-Timeline.mdx
+++ b/pages/DevTools-Overrides/Fetch-XHR-Timeline.mdx
@@ -25,7 +25,7 @@ Console snippets can only see requests that have already completed and are visib
 
 Add this inside a `<script>` tag before the closing `</head>` of the overridden HTML file. It runs before any other script and stores all captured calls in `window.__perfCalls`.
 
-<Snippet code={injectSnippet} />
+<Snippet code={injectSnippet} output={`(no output)`} />
 
 ---
 
@@ -33,7 +33,7 @@ Add this inside a `<script>` tag before the closing `</head>` of the overridden 
 
 Run this in the console after the page has loaded to see the captured data correlated with LCP.
 
-<Snippet code={readSnippet} />
+<Snippet code={readSnippet} output={`No data found. Make sure the inject snippet is active via DevTools Overrides and reload the page.`} />
 
 ---
 

--- a/pages/Interaction/Forced-Synchronous-Layout.mdx
+++ b/pages/Interaction/Forced-Synchronous-Layout.mdx
@@ -52,7 +52,9 @@ Geometric reads/writes — triggers the FSL warning:
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⚡ FSL Detector Active
+Monitoring class/style mutations and geometric property access.
+Call getFSLSummary() for the report or stopFSLDetector() to stop.`} />
 
 ### Understanding the Output
 

--- a/pages/Interaction/Input-Latency-Breakdown.mdx
+++ b/pages/Interaction/Input-Latency-Breakdown.mdx
@@ -23,7 +23,9 @@ INP measures the worst interaction, but understanding the pattern across many in
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⌨️ Input Latency Breakdown Active
+Interact with the page (click, type, etc.).
+Call getInputLatencyBreakdown() for the aggregated report.`} />
 
 ### Understanding the Results
 

--- a/pages/Interaction/Interactions.mdx
+++ b/pages/Interaction/Interactions.mdx
@@ -71,7 +71,9 @@ flowchart LR
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`👆 Interaction Tracking Active
+Interact with the page to see interaction details.
+Call getInteractionSummary() for a summary.`} />
 
 ### Understanding the Results
 

--- a/pages/Interaction/Layout-Shift-Loading-and-Interaction.mdx
+++ b/pages/Interaction/Layout-Shift-Loading-and-Interaction.mdx
@@ -64,7 +64,13 @@ flowchart TD
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📐 Layout Shift Tracking Active
+Current CLS: 🟢 0.0000
+Interact with the page to see new shifts.
+Call getLayoutShiftSummary() for full analysis.
+Deprecated API for given entry type.
+Deprecated API for given entry type.
+Deprecated API for given entry type.`} />
 
 ### Understanding the Results
 

--- a/pages/Interaction/Long-Animation-Frames-Helpers.mdx
+++ b/pages/Interaction/Long-Animation-Frames-Helpers.mdx
@@ -38,7 +38,10 @@ Advanced debugging utilities for [Long Animation Frames](/Interaction/Long-Anima
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔧 LoAF Helpers Loaded
+Observing long animation frames (>50ms)...
+Quick
+All`} />
 
 ### Understanding the Output
 

--- a/pages/Interaction/Long-Animation-Frames-Script-Attribution.mdx
+++ b/pages/Interaction/Long-Animation-Frames-Script-Attribution.mdx
@@ -67,7 +67,7 @@ graph LR
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`✅ No long frames detected`} />
 
 ## Quick Tips
 

--- a/pages/Interaction/Long-Animation-Frames.mdx
+++ b/pages/Interaction/Long-Animation-Frames.mdx
@@ -81,7 +81,9 @@ graph TB
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🎬 Long Animation Frames Tracking Active
+Frames with blocking duration will be logged.
+Call getLoAFSummary() for full analysis.`} />
 
 ### Understanding the Results
 

--- a/pages/Interaction/LongTask.mdx
+++ b/pages/Interaction/LongTask.mdx
@@ -39,7 +39,10 @@ When the main thread is blocked by a long task, the browser cannot respond to cl
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⏱️ Long Tasks Tracking Active
+Tasks blocking the main thread for >50ms will be logged.
+Call getLongTaskSummary() for statistics.
+Deprecated API for given entry type.`} />
 
 ### Understanding the Results
 

--- a/pages/Interaction/Scroll-Performance.mdx
+++ b/pages/Interaction/Scroll-Performance.mdx
@@ -31,7 +31,9 @@ Scroll jank is caused by work blocking the compositor thread: non-passive event 
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📜 Scroll Performance Analysis Active
+Scroll to measure FPS. Non-passive listener registrations will be warned.
+Call getScrollSummary() for the full report.`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Back-Forward-Cache.mdx
+++ b/pages/Loading/Back-Forward-Cache.mdx
@@ -93,7 +93,26 @@ flowchart TD
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🚀 bfcache Analysis Running...
+Results will appear shortly.
+Call checkBfcache() anytime to re-run analysis.
+🟡 bfcache
+📊
+ℹ️  This page was NOT restored from bfcache
+(Either first visit or bfcache was blocked on previous navigation)
+🕐 Navigation
+🔍 Potential
+[Object, Object]
+💡
+1. Close WebSocket connections before page hide.
+🧪 How to
+1. Run this snippet (you already did this ✓)
+2. Navigate to another page
+3. Click browser Back button
+4. Check console for restoration message
+Or use Chrome DevTools → Application → Back/forward cache
+console.groupEnd
+ℹ️  For detailed reasons, use Chrome 123+ and navigate back to this page.`} />
 
 ### Understanding bfcache
 

--- a/pages/Loading/CSS-Media-Queries-Analysis.mdx
+++ b/pages/Loading/CSS-Media-Queries-Analysis.mdx
@@ -12,7 +12,28 @@ This page provides two complementary analysis functions:
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📊 CSS Media Queries Analysis (min-width > 768px)
+Total @media rules found: 0
+Total classes: 0
+Total properties: 0
+console.groupEnd
+💾 POTENTIAL MOBILE SAVINGS
+Estimated CSS bytes that mobile doesn't
+└─ From inline CSS: 0 Bytes
+└─ From external files: 0 Bytes
+💡 By splitting these styles into separate files with media queries,
+mobile users won't need to download, parse, or process this CSS.
+console.groupEnd
+🔷 INLINE CSS (<style> tags)
+Media queries: 0
+Total size: 0 Bytes
+No inline media queries found for viewports > 768px.
+console.groupEnd
+📁 EXTERNAL FILES (.css files)
+Media queries: 0
+Total size: 0 Bytes
+No external file media queries found for viewports > 768px.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Cache-Strategy-Analysis.mdx
+++ b/pages/Loading/Cache-Strategy-Analysis.mdx
@@ -43,7 +43,24 @@ flowchart TD
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔍 Cache Strategy Analysis
+📊 Summary
+Total resources: 0
+Headers analyzed: 0 | CORS-restricted: 0 | Excluded (non-static/cross-origin): 0
+Cache efficiency: 0%
+Bandwidth saved by cache: N/A
+📋 Cache Strategy Distribution
+[]
+console.groupEnd
+💡 Additional Insights
+Protocol Distribution
+[]
+console.groupEnd
+console.groupEnd
+📌 Recommendations
+🔴 Cache efficiency is low (0%). Review caching strategy for all static assets.
+console.groupEnd
+console.groupEnd`} />
 
 ## Understanding the Results
 

--- a/pages/Loading/Client-Side-Redirect-Detection.mdx
+++ b/pages/Loading/Client-Side-Redirect-Detection.mdx
@@ -84,7 +84,16 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔄 Client-Side Redirect Detection
+📍 Current
+🌐 Server-Side
+✅ No server-side redirects
+📱 Client-Side Navigation
+✅ No client-side redirect detected
+⏱️ Navigation
+{TTFB: 0.0ms, DOM Content Loaded: 4.5ms, Load Complete: 4.8ms, Redirect Time: N/A, DNS Lookup: 0.0ms, TCP Connect: 0.0ms, Request/Response: 4.4ms}
+ℹ️
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Content-Visibility.mdx
+++ b/pages/Loading/Content-Visibility.mdx
@@ -16,7 +16,16 @@ This snippet code is based on the [script](https://github.com/corewebvitals/page
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔍 Content-Visibility Detection
+No content-visibility usage found.
+💡 Consider applying content-visibility: auto to:
+• Footer sections
+• Below-the-fold content
+• Long lists or card grids
+• Tab content that is not initially visible
+• Accordion/collapsible content
+console.groupEnd
+To find optimization opportunities,`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Critical-CSS-Detection.mdx
+++ b/pages/Loading/Critical-CSS-Detection.mdx
@@ -61,7 +61,24 @@ This is why the web performance community targets **HTML + critical CSS + critic
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🎯 Critical CSS Detection
+Page CSS
+External stylesheets:        0
+Non-blocking (media query):  0
+Inline <style> blocks:       0
+Total external CSS (wire):   0 B
+Total inline CSS:            0 B
+✅ No render-blocking stylesheets detected.
+✅ No critical CSS issues detected.
+📖 Critical CSS Best Practices
+• Inline critical above-the-fold CSS in <head> (target: < 14 KB)
+• Defer non-critical CSS:
+<link rel="stylesheet" href="styles.css" media="print" onload="this.media='all'">
+• Preload critical external CSS: <link rel="preload" as="style" href="...">
+• Use Chrome DevTools Coverage tab (Ctrl+Shift+P → Coverage) to find unused CSS
+• Automate critical CSS extraction with tools like critical or Critters
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Event-Processing-Time.mdx
+++ b/pages/Loading/Event-Processing-Time.mdx
@@ -42,7 +42,19 @@ gantt
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⏱️ Page
+Network time: 4ms (91%)
+Processing time: 0ms (9%)
+🔄 Redirect                0.00 ms    0.0%  ░░░░░░░░░░░░░░░░░░░░
+📥 Response                4.30 ms   91.5%  █████████████████████████████████████
+🏗️ DOM Processing          0.10 ms    2.1%  █░░░░░░░░░░░░░░░░░░░
+📦 Resource Loading        0.30 ms    6.4%  ███░░░░░░░░░░░░░░░░░
+Key
+TTFB (Time to First Byte): 0ms
+Load Complete: 5ms
+💡 Bottleneck
+Response takes 91% of total load time
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/FCP.mdx
+++ b/pages/Loading/FCP.mdx
@@ -21,7 +21,7 @@ Unlike LCP, FCP fires as soon as _any_ content appears, making it the earliest s
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`(no output)`} />
 
 ### Phase Breakdown
 

--- a/pages/Loading/Find-Above-The-Fold-Lazy-Loaded-Images.mdx
+++ b/pages/Loading/Find-Above-The-Fold-Lazy-Loaded-Images.mdx
@@ -11,7 +11,9 @@ The snippet identifies images with `loading="lazy"` or `[data-src]` in the viewp
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔍 Lazy Loading Detection - Above The Fold
+✅ Good job! No lazily loaded images found in the viewport.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Find-Images-With-Lazy-and-Fetchpriority.mdx
+++ b/pages/Loading/Find-Images-With-Lazy-and-Fetchpriority.mdx
@@ -28,7 +28,9 @@ Based on the [script](https://twitter.com/csswizardry/status/1714697877245632832
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔍 Lazy + Fetchpriority Conflict Check
+✅ No conflicts found. No elements have both loading="lazy" and fetchpriority="high".
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport.mdx
+++ b/pages/Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport.mdx
@@ -18,7 +18,9 @@ This script detects images without `loading="lazy"` or `[data-src]` attributes t
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`💡 Lazy Loading Opportunities
+✅ Good job! All images outside the viewport have lazy loading. font-weight: bold
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Find-render-blocking-resources.mdx
+++ b/pages/Loading/Find-render-blocking-resources.mdx
@@ -63,7 +63,14 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🚧 Render-Blocking Resources
+✅ No render-blocking resources found!
+The page has no resources blocking initial render.
+💡 This could
+• CSS is inlined or loaded asynchronously
+• Scripts use async or defer attributes
+• Critical resources are optimized
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/First-And-Third-Party-Script-Info.mdx
+++ b/pages/Loading/First-And-Third-Party-Script-Info.mdx
@@ -27,7 +27,16 @@ Analyzes all scripts loaded on the page, separating them into first-party (your 
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📊 Script
+Overall
+Total scripts: 0
+🏠 First-Party Scripts (0)
+No first-party scripts found.
+console.groupEnd
+🌐 Third-Party Scripts (0)
+✅ No third-party scripts found!
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/First-And-Third-Party-Script-Timings.mdx
+++ b/pages/Loading/First-And-Third-Party-Script-Timings.mdx
@@ -38,7 +38,23 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⏱️ Script Timing Analysis
+Summary (averages):
+First-Party    Third-Party
+───────────    ───────────
+🔍 DNS Lookup                  -                -
+🔌 TCP Connection              -                -
+🔒 TLS/SSL                     -                -
+📤 Request (TTFB)              -                -
+📥 Response                    -                -
+⏱️ Total                       -                -
+🏠 First-Party Scripts (0)
+No first-party scripts found.
+console.groupEnd
+🌐 Third-Party Scripts (0)
+✅ No third-party scripts!
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold.mdx
+++ b/pages/Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold.mdx
@@ -28,7 +28,28 @@ Analyzes font loading strategy by comparing preloaded fonts, loaded fonts, and f
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔤 Font Loading Analysis
+Preloaded fonts: 0
+Loaded fonts: 0
+Used above the fold: 0
+⬇️ Preloaded Fonts (0)
+No fonts preloaded via <link rel='preload'>.
+console.groupEnd
+📦 Loaded Fonts (0)
+No web fonts loaded (using system fonts only).
+console.groupEnd
+👁️ Fonts Used Above The Fold (0)
+No text elements found above the fold.
+console.groupEnd
+📝 Font Loading Best Practices
+1. Preload critical fonts used above the fold
+2. Use font-display: swap or optional
+3. Always include crossorigin attribute on font preloads
+4. Self-host fonts when possible for better control
+5. Subset fonts to include only needed characters
+6. Use WOFF2 format for best compression
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Inline-CSS-Info-and-Size.mdx
+++ b/pages/Loading/Inline-CSS-Info-and-Size.mdx
@@ -26,7 +26,10 @@ Analyzes all inline `<style>` tags on the page, measuring their size and identif
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📝 Inline CSS Analysis
+✅ No inline <style> tags found.
+The page uses external stylesheets only.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Inline-Script-Info-and-Size.mdx
+++ b/pages/Loading/Inline-Script-Info-and-Size.mdx
@@ -35,7 +35,10 @@ Analyzes all inline `<script>` tags on the page, measuring their size and identi
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📜 Inline Script Analysis
+✅ No inline scripts found.
+The page uses external scripts only.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/JS-Execution-Time-Breakdown.mdx
+++ b/pages/Loading/JS-Execution-Time-Breakdown.mdx
@@ -53,7 +53,28 @@ V8 must parse every byte of JavaScript before executing it. Parse time scales ro
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⚡ JavaScript Execution Time Breakdown
+📅 Page Load
+DOM Interactive             5ms  ███████████████████░
+DOM Content Loaded          5ms  ███████████████████░
+Load event                  5ms  ████████████████████
+JS blocking scripts contribute ~0% of domInteractive (- est.)
+📊 Script
+Total scripts:          0
+Total transfer size:    -
+Total decoded size:     -
+Compression ratio:      -
+Cost Estimates (download + parse):
+Total download time:    -
+Est. total parse time:  - (~1ms/KB decoded)
+Est. total JS cost:     -
+📝 Recommendations
+✅ No critical JS issues found.
+💡 For measured execution time (not estimates):
+Run the Long Animation Frames Script Attribution snippet to measure
+actual execution time during user interactions.
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Prefetch-Resource-Validation.mdx
+++ b/pages/Loading/Prefetch-Resource-Validation.mdx
@@ -54,7 +54,8 @@ graph LR
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`✅ No prefetch hints found (rel="prefetch").
+ℹ️ Prefetch is for future navigation resources. Use it sparingly for predictable user journeys.`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Priority-Hints-Audit.mdx
+++ b/pages/Loading/Priority-Hints-Audit.mdx
@@ -32,7 +32,14 @@ Audits all `fetchpriority` attribute usage across the page — covering non-imag
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🎯 Priority Hints Audit
+Total elements with fetchpriority: 0
+• Images: 0 (see "Find Images With Lazy and Fetchpriority" for image-specific checks)
+• Non-image resources: 0
+• Preloads with fetchpriority: 0
+Priority breakdown: high=0, low=0, auto=0
+ℹ️ No fetchpriority attributes found on this page.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Resource-Hints-Validation.mdx
+++ b/pages/Loading/Resource-Hints-Validation.mdx
@@ -44,7 +44,44 @@ The snippet includes a check that compares DOM elements (like `<img>` tags) agai
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔍 Resource Hints Validation
+Preload hints: 0
+Preconnect hints: 0
+DNS-prefetch hints: 0
+Total resources loaded: 0
+Unique domains accessed: 1
+1. Preload Validation
+ℹ️ No preload hints found.
+console.groupEnd
+2. Preconnect Validation
+ℹ️ No preconnect hints found.
+console.groupEnd
+3. DNS-Prefetch Validation
+ℹ️ No dns-prefetch hints found.
+console.groupEnd
+⚠️ Redundant Hints
+✅ No redundant hints found.
+console.groupEnd
+⚠️ Performance API Limitations
+✅ All DOM image domains are captured in Performance API.
+console.groupEnd
+4. Optimization Opportunities
+✅ All frequently-used domains have appropriate hints.
+console.groupEnd
+📝 Best Practices
+✅ Use for critical resources on current page
+❌ Don't preload resources not used on current page
+⚡ Limit to few most critical resources
+✅ Use for critical third-party domains
+✅ Best for domains with many requests
+❌ Don't use for domains not accessed
+⚡ Limit to few most important domains
+✅ Use for non-critical third-party domains
+✅ Good for domains with few requests
+ℹ️ Less impact than preconnect
+console.groupEnd
+✅ Excellent! All resource hints are properly configured.
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Resource-Hints.mdx
+++ b/pages/Loading/Resource-Hints.mdx
@@ -37,7 +37,26 @@ preload/modulepreload → preconnect → dns-prefetch → prefetch → prerender
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🔗 Resource Hints Analysis
+⚪ ⚡ preload: 0
+⚪ 📦 modulepreload: 0
+⚪ 🔌 preconnect: 0
+⚪ 🔍 dns-prefetch: 0
+⚪ 📥 prefetch: 0
+⚪ 🖼️ prerender: 0
+Total hints: 0
+✅ No issues found with resource hints.
+📝 Best Practices
+Preload (current page critical resources):
+<link rel="preload" href="/font.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="preload" href="/hero.webp" as="image" fetchpriority="high">
+Preconnect (third-party origins):
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+Prefetch (next page resources):
+<link rel="prefetch" href="/next-page.js" as="script">
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/SSR-Hydration-Data-Analysis.mdx
+++ b/pages/Loading/SSR-Hydration-Data-Analysis.mdx
@@ -32,7 +32,14 @@ Analyzes hydration data scripts used by SSR frameworks like Next.js, Nuxt, Remix
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`🚀 SSR Framework Hydration Analysis
+📭 No SSR framework hydration data detected.
+This page may be:
+• A static HTML page
+• A client-side rendered SPA
+• Using a framework not yet supported by this snippet
+Found 0 other inline scripts (0 B)
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Script-Loading.mdx
+++ b/pages/Loading/Script-Loading.mdx
@@ -80,7 +80,26 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📜 Script Loading Analysis
+Total external scripts: 0
+Total inline scripts: 0
+Total size: -
+By loading
+🔴 Blocking: 0 (-)
+⚡ Async: 0
+📋 Defer: 0
+📦 Module: 0
+📝 Best Practices
+For most scripts (need DOM, run in order):
+<script src="app.js" defer></script>
+For independent scripts (analytics, ads):
+<script src="analytics.js" async></script>
+For ES
+<script type="module" src="app.mjs"></script>
+For critical inline
+<script>/* Only essential initialization */</script>
+console.groupEnd
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/pages/Loading/Service-Worker-Analysis.mdx
+++ b/pages/Loading/Service-Worker-Analysis.mdx
@@ -67,7 +67,7 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`⚠️ Service Workers not supported in this browser`} />
 
 ## Interpreting the Results
 

--- a/pages/Loading/TTFB.mdx
+++ b/pages/Loading/TTFB.mdx
@@ -26,7 +26,7 @@ Time to First Byte (TTFB) measures the time from when the user starts navigating
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`(no output)`} />
 
 ## Measure TTFB sub-parts
 
@@ -66,7 +66,10 @@ sequenceDiagram
 
 ### Snippet
 
-<Snippet code={snippet2} />
+<Snippet code={snippet2} output={`⏱️
+────────────────────────────────────────────────────────────
+📊 Total TTFB                   0.00 ms
+console.groupEnd`} />
 
 ## Measure TTFB for all resources
 
@@ -76,7 +79,7 @@ Analyzes TTFB for every resource loaded on the page (scripts, stylesheets, image
 
 ### Snippet
 
-<Snippet code={snippet3} />
+<Snippet code={snippet3} output={`(no output)`} />
 
 ## Browser Support
 

--- a/pages/Loading/Validate-Preload-Async-Defer-Scripts.mdx
+++ b/pages/Loading/Validate-Preload-Async-Defer-Scripts.mdx
@@ -64,7 +64,8 @@ With preload on async script:
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`✅ No script preloads found (rel="preload" as="script").
+ℹ️ This is fine - only preload scripts if they're critical and blocking.`} />
 
 ### Understanding the Results
 

--- a/pages/Media/Image-Element-Audit.mdx
+++ b/pages/Media/Image-Element-Audit.mdx
@@ -70,7 +70,7 @@ For maximum format coverage, wrap images in a `<picture>` element:
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`No <img> elements found on this page.`} />
 
 ### Understanding the Results
 

--- a/pages/Media/SVG-Embedded-Bitmap-Analysis.mdx
+++ b/pages/Media/SVG-Embedded-Bitmap-Analysis.mdx
@@ -37,7 +37,7 @@ The correct pattern is to reference bitmap assets as separate files:
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`No SVG resources found on this page.`} />
 
 ### Understanding the Results
 

--- a/pages/Media/Video-Element-Audit.mdx
+++ b/pages/Media/Video-Element-Audit.mdx
@@ -58,7 +58,7 @@ Every video on a page falls into one of three roles, each with its own optimal c
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`No <video> elements found on this page.`} />
 
 ### Understanding the Results
 

--- a/pages/Resources/Network-Bandwidth-Connection-Quality.mdx
+++ b/pages/Resources/Network-Bandwidth-Connection-Quality.mdx
@@ -23,7 +23,11 @@ Network quality directly affects web performance. Segmenting metrics by connecti
 
 ### Snippet
 
-<Snippet code={snippet} />
+<Snippet code={snippet} output={`📡 Network
+Connection
+{Connection Type: unknown, Effective Type: 4g, Downlink (Mbps): 10, RTT (ms): 0, Save-Data: Disabled}
+👂 Listening for connection changes... (navigate to trigger)
+console.groupEnd`} />
 
 ### Understanding the Results
 

--- a/scripts/capture-outputs.js
+++ b/scripts/capture-outputs.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Runs each snippet in a headless browser and captures console output.
+// Writes results to snippets/outputs.json
+
+const { chromium } = require("playwright");
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const SNIPPETS_DIR = path.join(ROOT, "snippets");
+const OUTPUT_FILE = path.join(SNIPPETS_DIR, "outputs.json");
+
+// Collect all .js files recursively from snippets/
+function getSnippetFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      files.push(...getSnippetFiles(path.join(dir, entry.name)));
+    } else if (entry.name.endsWith(".js")) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+// Convert absolute path to a relative key like "CoreWebVitals/LCP"
+function fileToKey(filePath) {
+  const rel = path.relative(SNIPPETS_DIR, filePath);
+  return rel.replace(/\.js$/, "");
+}
+
+async function captureOutput(browser, code) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const logs = [];
+
+  // Capture all console messages
+  page.on("console", (msg) => {
+    const type = msg.type(); // log, warn, error, info, etc.
+    const text = msg.text();
+    logs.push({ type, text });
+  });
+
+  // Navigate to a blank page (snippets use browser APIs like performance)
+  await page.goto("about:blank");
+
+  try {
+    // Execute the snippet code in the page context
+    await page.evaluate(code);
+    // Give async snippets time to finish
+    await page.waitForTimeout(200);
+  } catch (err) {
+    logs.push({ type: "error", text: `Execution error: ${err.message}` });
+  }
+
+  await context.close();
+  return logs;
+}
+
+// Remove %c directives and their associated CSS style arguments
+// e.g. "%cLCP Active font-weight: bold" → "LCP Active"
+function cleanConsoleText(text) {
+  // Split on CSS style args that follow %c (they look like CSS property strings)
+  // Strategy: remove %c, then remove the CSS strings that follow as separate tokens
+  let result = text;
+
+  // Remove %c placeholders
+  result = result.replace(/%c/g, "");
+
+  // Remove CSS style strings — they appear as standalone segments containing
+  // CSS properties like "font-weight: bold; font-size: 14px;"
+  result = result
+    .split("\n")
+    .map((line) =>
+      // A line is a CSS style arg if it matches "prop: value;" pattern and
+      // has no normal words/sentences (no spaces before the first colon)
+      /^[\w-]+\s*:/.test(line.trim()) && !/^(https?|file):/.test(line.trim())
+        ? null
+        : line,
+    )
+    .filter((line) => line !== null)
+    .join("\n");
+
+  // Also remove inline CSS blobs that ended up on same line after %c removal
+  // e.g. "LCP Active font-weight: bold; font-size: 14px;"
+  result = result.replace(/\s+([\w-]+\s*:[^;]+;(\s*[\w-]+\s*:[^;]+;)*)/g, "");
+
+  return result.trim();
+}
+
+function formatLogs(logs) {
+  return logs
+    .filter((l) => l.text && l.text.trim() !== "")
+    .map((l) => cleanConsoleText(l.text))
+    .filter((t) => t !== "")
+    .join("\n");
+}
+
+async function main() {
+  const snippetFiles = getSnippetFiles(SNIPPETS_DIR);
+  console.log(`Found ${snippetFiles.length} snippets\n`);
+
+  const browser = await chromium.launch();
+  const results = {};
+
+  for (const file of snippetFiles) {
+    const key = fileToKey(file);
+    const code = fs.readFileSync(file, "utf-8");
+
+    process.stdout.write(`  Running: ${key} ... `);
+
+    try {
+      const logs = await captureOutput(browser, code);
+      const output = formatLogs(logs);
+      results[key] = { output: output || "(no output)", error: null };
+      console.log("✓");
+    } catch (err) {
+      results[key] = { output: null, error: err.message };
+      console.log(`✗ ${err.message}`);
+    }
+  }
+
+  await browser.close();
+
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(results, null, 2));
+  console.log(`\nOutputs saved to snippets/outputs.json`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/inject-outputs.js
+++ b/scripts/inject-outputs.js
@@ -1,0 +1,105 @@
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const PAGES_DIR = path.join(ROOT, "pages");
+const SNIPPETS_DIR = path.join(ROOT, "snippets");
+const OUTPUT_FILE = path.join(SNIPPETS_DIR, "outputs.json");
+
+if (!fs.existsSync(OUTPUT_FILE)) {
+  console.error(
+    "snippets/outputs.json not found. Run capture-outputs.js first.",
+  );
+  process.exit(1);
+}
+
+const outputs = JSON.parse(fs.readFileSync(OUTPUT_FILE, "utf-8"));
+
+function getMdxFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      files.push(...getMdxFiles(path.join(dir, entry.name)));
+    } else if (entry.name.endsWith(".mdx")) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+function extractKeyFromImport(importLine) {
+  const match = importLine.match(/snippets\/(.+?)\.js\?raw/);
+  return match ? match[1] : null;
+}
+
+function getSnippetImports(content) {
+  const map = {};
+  const lines = content.split("\n");
+  for (const line of lines) {
+    if (!line.includes("snippets/") || !line.includes("?raw")) continue;
+    const varMatch = line.match(/import\s+(\w+)\s+from/);
+    const key = extractKeyFromImport(line);
+    if (varMatch && key) {
+      map[varMatch[1]] = key;
+    }
+  }
+  return map;
+}
+
+function processFile(mdxPath) {
+  let content = fs.readFileSync(mdxPath, "utf-8");
+  const rel = path.relative(ROOT, mdxPath);
+
+  const snippetImports = getSnippetImports(content);
+  if (Object.keys(snippetImports).length === 0) return false;
+
+  let changed = false;
+
+  for (const [varName, outputKey] of Object.entries(snippetImports)) {
+    const outputData = outputs[outputKey];
+    if (!outputData || !outputData.output) continue;
+
+    const outputText = outputData.output;
+
+    const withoutOutput = new RegExp(
+      `<Snippet\\s+code=\\{${varName}\\}\\s*/>`,
+      "g",
+    );
+    const withOutput = new RegExp(
+      `<Snippet\\s+code=\\{${varName}\\}\\s+output=\\{[^}]+\\}\\s*/>`,
+      "g",
+    );
+
+    const escaped = outputText
+      .replace(/\\/g, "\\\\")
+      .replace(/`/g, "\\`")
+      .replace(/\$/g, "\\$");
+
+    const replacement = `<Snippet code={${varName}} output={\`${escaped}\`} />`;
+
+    if (withoutOutput.test(content)) {
+      content = content.replace(withoutOutput, replacement);
+      changed = true;
+    } else if (withOutput.test(content)) {
+      content = content.replace(withOutput, replacement);
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    fs.writeFileSync(mdxPath, content);
+    console.log(`  updated: ${rel}`);
+  }
+
+  return changed;
+}
+
+const mdxFiles = getMdxFiles(PAGES_DIR);
+console.log(`Processing ${mdxFiles.length} MDX files...\n`);
+
+let updatedCount = 0;
+for (const file of mdxFiles) {
+  if (processFile(file)) updatedCount++;
+}
+
+console.log(`\nDone. Updated ${updatedCount} files.`);

--- a/snippets/outputs.json
+++ b/snippets/outputs.json
@@ -1,0 +1,206 @@
+{
+  "CoreWebVitals/CLS": {
+    "output": "Call getCLS() anytime to check current value.",
+    "error": null
+  },
+  "CoreWebVitals/INP": {
+    "output": "⚡ INP Tracking Active\nInteractions with duration > 16ms will be tracked.\nCall getINP() to see current INP value.\nCall getINPDetails() for full interaction list.",
+    "error": null
+  },
+  "CoreWebVitals/LCP-Image-Entropy": {
+    "output": "Deprecated API for given entry type.\n🖼️ Image Entropy Analysis\nNo images with measurable entropy found.\n(Data URLs and cross-origin images without CORS are excluded)\nconsole.groupEnd",
+    "error": null
+  },
+  "CoreWebVitals/LCP-Subparts": {
+    "output": "📊 LCP Subparts Analysis Active\nWaiting for LCP...",
+    "error": null
+  },
+  "CoreWebVitals/LCP-Trail": {
+    "output": "⏱️ LCP Trail Active\nHighlights all LCP candidate elements with distinct colors.\nDeprecated API for given entry type.",
+    "error": null
+  },
+  "CoreWebVitals/LCP-Video-Candidate": {
+    "output": "Deprecated API for given entry type.\n⚠️ No LCP entries found. Run this snippet before interacting with the page, or reload and run it immediately.",
+    "error": null
+  },
+  "CoreWebVitals/LCP": {
+    "output": "⏱️ LCP Tracking Active\nLCP may update as larger elements load.",
+    "error": null
+  },
+  "DevTools-Overrides/Fetch-XHR-Timeline-inject": {
+    "output": "(no output)",
+    "error": null
+  },
+  "DevTools-Overrides/Fetch-XHR-Timeline-read": {
+    "output": "No data found. Make sure the inject snippet is active via DevTools Overrides and reload the page.",
+    "error": null
+  },
+  "Interaction/Forced-Synchronous-Layout": {
+    "output": "⚡ FSL Detector Active\nMonitoring class/style mutations and geometric property access.\nCall getFSLSummary() for the report or stopFSLDetector() to stop.",
+    "error": null
+  },
+  "Interaction/Input-Latency-Breakdown": {
+    "output": "⌨️ Input Latency Breakdown Active\nInteract with the page (click, type, etc.).\nCall getInputLatencyBreakdown() for the aggregated report.",
+    "error": null
+  },
+  "Interaction/Interactions": {
+    "output": "👆 Interaction Tracking Active\nInteract with the page to see interaction details.\nCall getInteractionSummary() for a summary.",
+    "error": null
+  },
+  "Interaction/Layout-Shift-Loading-and-Interaction": {
+    "output": "📐 Layout Shift Tracking Active\nCurrent CLS: 🟢 0.0000\nInteract with the page to see new shifts.\nCall getLayoutShiftSummary() for full analysis.\nDeprecated API for given entry type.\nDeprecated API for given entry type.\nDeprecated API for given entry type.",
+    "error": null
+  },
+  "Interaction/Long-Animation-Frames-Helpers": {
+    "output": "🔧 LoAF Helpers Loaded\nObserving long animation frames (>50ms)...\nQuick\nAll",
+    "error": null
+  },
+  "Interaction/Long-Animation-Frames-Script-Attribution": {
+    "output": "✅ No long frames detected",
+    "error": null
+  },
+  "Interaction/Long-Animation-Frames": {
+    "output": "🎬 Long Animation Frames Tracking Active\nFrames with blocking duration will be logged.\nCall getLoAFSummary() for full analysis.",
+    "error": null
+  },
+  "Interaction/LongTask": {
+    "output": "⏱️ Long Tasks Tracking Active\nTasks blocking the main thread for >50ms will be logged.\nCall getLongTaskSummary() for statistics.\nDeprecated API for given entry type.",
+    "error": null
+  },
+  "Interaction/Scroll-Performance": {
+    "output": "📜 Scroll Performance Analysis Active\nScroll to measure FPS. Non-passive listener registrations will be warned.\nCall getScrollSummary() for the full report.",
+    "error": null
+  },
+  "Loading/Back-Forward-Cache": {
+    "output": "🚀 bfcache Analysis Running...\nResults will appear shortly.\nCall checkBfcache() anytime to re-run analysis.\n🟡 bfcache\n📊\nℹ️  This page was NOT restored from bfcache\n(Either first visit or bfcache was blocked on previous navigation)\n🕐 Navigation\n🔍 Potential\n[Object, Object]\n💡\n1. Close WebSocket connections before page hide.\n🧪 How to\n1. Run this snippet (you already did this ✓)\n2. Navigate to another page\n3. Click browser Back button\n4. Check console for restoration message\nOr use Chrome DevTools → Application → Back/forward cache\nconsole.groupEnd\nℹ️  For detailed reasons, use Chrome 123+ and navigate back to this page.",
+    "error": null
+  },
+  "Loading/CSS-Media-Queries-Analysis": {
+    "output": "📊 CSS Media Queries Analysis (min-width > 768px)\nTotal @media rules found: 0\nTotal classes: 0\nTotal properties: 0\nconsole.groupEnd\n💾 POTENTIAL MOBILE SAVINGS\nEstimated CSS bytes that mobile doesn't\n└─ From inline CSS: 0 Bytes\n└─ From external files: 0 Bytes\n💡 By splitting these styles into separate files with media queries,\nmobile users won't need to download, parse, or process this CSS.\nconsole.groupEnd\n🔷 INLINE CSS (<style> tags)\nMedia queries: 0\nTotal size: 0 Bytes\nNo inline media queries found for viewports > 768px.\nconsole.groupEnd\n📁 EXTERNAL FILES (.css files)\nMedia queries: 0\nTotal size: 0 Bytes\nNo external file media queries found for viewports > 768px.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Cache-Strategy-Analysis": {
+    "output": "🔍 Cache Strategy Analysis\n📊 Summary\nTotal resources: 0\nHeaders analyzed: 0 | CORS-restricted: 0 | Excluded (non-static/cross-origin): 0\nCache efficiency: 0%\nBandwidth saved by cache: N/A\n📋 Cache Strategy Distribution\n[]\nconsole.groupEnd\n💡 Additional Insights\nProtocol Distribution\n[]\nconsole.groupEnd\nconsole.groupEnd\n📌 Recommendations\n🔴 Cache efficiency is low (0%). Review caching strategy for all static assets.\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Client-Side-Redirect-Detection": {
+    "output": "🔄 Client-Side Redirect Detection\n📍 Current\n🌐 Server-Side\n✅ No server-side redirects\n📱 Client-Side Navigation\n✅ No client-side redirect detected\n⏱️ Navigation\n{TTFB: 0.0ms, DOM Content Loaded: 4.5ms, Load Complete: 4.8ms, Redirect Time: N/A, DNS Lookup: 0.0ms, TCP Connect: 0.0ms, Request/Response: 4.4ms}\nℹ️\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Content-Visibility": {
+    "output": "🔍 Content-Visibility Detection\nNo content-visibility usage found.\n💡 Consider applying content-visibility: auto to:\n• Footer sections\n• Below-the-fold content\n• Long lists or card grids\n• Tab content that is not initially visible\n• Accordion/collapsible content\nconsole.groupEnd\nTo find optimization opportunities,",
+    "error": null
+  },
+  "Loading/Critical-CSS-Detection": {
+    "output": "🎯 Critical CSS Detection\nPage CSS\nExternal stylesheets:        0\nNon-blocking (media query):  0\nInline <style> blocks:       0\nTotal external CSS (wire):   0 B\nTotal inline CSS:            0 B\n✅ No render-blocking stylesheets detected.\n✅ No critical CSS issues detected.\n📖 Critical CSS Best Practices\n• Inline critical above-the-fold CSS in <head> (target: < 14 KB)\n• Defer non-critical CSS:\n<link rel=\"stylesheet\" href=\"styles.css\" media=\"print\" onload=\"this.media='all'\">\n• Preload critical external CSS: <link rel=\"preload\" as=\"style\" href=\"...\">\n• Use Chrome DevTools Coverage tab (Ctrl+Shift+P → Coverage) to find unused CSS\n• Automate critical CSS extraction with tools like critical or Critters\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Event-Processing-Time": {
+    "output": "⏱️ Page\nNetwork time: 4ms (91%)\nProcessing time: 0ms (9%)\n🔄 Redirect                0.00 ms    0.0%  ░░░░░░░░░░░░░░░░░░░░\n📥 Response                4.30 ms   91.5%  █████████████████████████████████████\n🏗️ DOM Processing          0.10 ms    2.1%  █░░░░░░░░░░░░░░░░░░░\n📦 Resource Loading        0.30 ms    6.4%  ███░░░░░░░░░░░░░░░░░\nKey\nTTFB (Time to First Byte): 0ms\nLoad Complete: 5ms\n💡 Bottleneck\nResponse takes 91% of total load time\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/FCP": {
+    "output": "(no output)",
+    "error": null
+  },
+  "Loading/Find-Above-The-Fold-Lazy-Loaded-Images": {
+    "output": "🔍 Lazy Loading Detection - Above The Fold\n✅ Good job! No lazily loaded images found in the viewport.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Find-Images-With-Lazy-and-Fetchpriority": {
+    "output": "🔍 Lazy + Fetchpriority Conflict Check\n✅ No conflicts found. No elements have both loading=\"lazy\" and fetchpriority=\"high\".\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Find-non-Lazy-Loaded-Images-outside-of-the-viewport": {
+    "output": "💡 Lazy Loading Opportunities\n✅ Good job! All images outside the viewport have lazy loading. font-weight: bold\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Find-render-blocking-resources": {
+    "output": "🚧 Render-Blocking Resources\n✅ No render-blocking resources found!\nThe page has no resources blocking initial render.\n💡 This could\n• CSS is inlined or loaded asynchronously\n• Scripts use async or defer attributes\n• Critical resources are optimized\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/First-And-Third-Party-Script-Info": {
+    "output": "📊 Script\nOverall\nTotal scripts: 0\n🏠 First-Party Scripts (0)\nNo first-party scripts found.\nconsole.groupEnd\n🌐 Third-Party Scripts (0)\n✅ No third-party scripts found!\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/First-And-Third-Party-Script-Timings": {
+    "output": "⏱️ Script Timing Analysis\nSummary (averages):\nFirst-Party    Third-Party\n───────────    ───────────\n🔍 DNS Lookup                  -                -\n🔌 TCP Connection              -                -\n🔒 TLS/SSL                     -                -\n📤 Request (TTFB)              -                -\n📥 Response                    -                -\n⏱️ Total                       -                -\n🏠 First-Party Scripts (0)\nNo first-party scripts found.\nconsole.groupEnd\n🌐 Third-Party Scripts (0)\n✅ No third-party scripts!\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Fonts-Preloaded-Loaded-and-used-above-the-fold": {
+    "output": "🔤 Font Loading Analysis\nPreloaded fonts: 0\nLoaded fonts: 0\nUsed above the fold: 0\n⬇️ Preloaded Fonts (0)\nNo fonts preloaded via <link rel='preload'>.\nconsole.groupEnd\n📦 Loaded Fonts (0)\nNo web fonts loaded (using system fonts only).\nconsole.groupEnd\n👁️ Fonts Used Above The Fold (0)\nNo text elements found above the fold.\nconsole.groupEnd\n📝 Font Loading Best Practices\n1. Preload critical fonts used above the fold\n2. Use font-display: swap or optional\n3. Always include crossorigin attribute on font preloads\n4. Self-host fonts when possible for better control\n5. Subset fonts to include only needed characters\n6. Use WOFF2 format for best compression\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Inline-CSS-Info-and-Size": {
+    "output": "📝 Inline CSS Analysis\n✅ No inline <style> tags found.\nThe page uses external stylesheets only.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Inline-Script-Info-and-Size": {
+    "output": "📜 Inline Script Analysis\n✅ No inline scripts found.\nThe page uses external scripts only.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/JS-Execution-Time-Breakdown": {
+    "output": "⚡ JavaScript Execution Time Breakdown\n📅 Page Load\nDOM Interactive             5ms  ███████████████████░\nDOM Content Loaded          5ms  ███████████████████░\nLoad event                  5ms  ████████████████████\nJS blocking scripts contribute ~0% of domInteractive (- est.)\n📊 Script\nTotal scripts:          0\nTotal transfer size:    -\nTotal decoded size:     -\nCompression ratio:      -\nCost Estimates (download + parse):\nTotal download time:    -\nEst. total parse time:  - (~1ms/KB decoded)\nEst. total JS cost:     -\n📝 Recommendations\n✅ No critical JS issues found.\n💡 For measured execution time (not estimates):\nRun the Long Animation Frames Script Attribution snippet to measure\nactual execution time during user interactions.\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Prefetch-Resource-Validation": {
+    "output": "✅ No prefetch hints found (rel=\"prefetch\").\nℹ️ Prefetch is for future navigation resources. Use it sparingly for predictable user journeys.",
+    "error": null
+  },
+  "Loading/Priority-Hints-Audit": {
+    "output": "🎯 Priority Hints Audit\nTotal elements with fetchpriority: 0\n• Images: 0 (see \"Find Images With Lazy and Fetchpriority\" for image-specific checks)\n• Non-image resources: 0\n• Preloads with fetchpriority: 0\nPriority breakdown: high=0, low=0, auto=0\nℹ️ No fetchpriority attributes found on this page.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Resource-Hints-Validation": {
+    "output": "🔍 Resource Hints Validation\nPreload hints: 0\nPreconnect hints: 0\nDNS-prefetch hints: 0\nTotal resources loaded: 0\nUnique domains accessed: 1\n1. Preload Validation\nℹ️ No preload hints found.\nconsole.groupEnd\n2. Preconnect Validation\nℹ️ No preconnect hints found.\nconsole.groupEnd\n3. DNS-Prefetch Validation\nℹ️ No dns-prefetch hints found.\nconsole.groupEnd\n⚠️ Redundant Hints\n✅ No redundant hints found.\nconsole.groupEnd\n⚠️ Performance API Limitations\n✅ All DOM image domains are captured in Performance API.\nconsole.groupEnd\n4. Optimization Opportunities\n✅ All frequently-used domains have appropriate hints.\nconsole.groupEnd\n📝 Best Practices\n✅ Use for critical resources on current page\n❌ Don't preload resources not used on current page\n⚡ Limit to few most critical resources\n✅ Use for critical third-party domains\n✅ Best for domains with many requests\n❌ Don't use for domains not accessed\n⚡ Limit to few most important domains\n✅ Use for non-critical third-party domains\n✅ Good for domains with few requests\nℹ️ Less impact than preconnect\nconsole.groupEnd\n✅ Excellent! All resource hints are properly configured.\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Resource-Hints": {
+    "output": "🔗 Resource Hints Analysis\n⚪ ⚡ preload: 0\n⚪ 📦 modulepreload: 0\n⚪ 🔌 preconnect: 0\n⚪ 🔍 dns-prefetch: 0\n⚪ 📥 prefetch: 0\n⚪ 🖼️ prerender: 0\nTotal hints: 0\n✅ No issues found with resource hints.\n📝 Best Practices\nPreload (current page critical resources):\n<link rel=\"preload\" href=\"/font.woff2\" as=\"font\" type=\"font/woff2\" crossorigin>\n<link rel=\"preload\" href=\"/hero.webp\" as=\"image\" fetchpriority=\"high\">\nPreconnect (third-party origins):\n<link rel=\"preconnect\" href=\"https://fonts.googleapis.com\">\n<link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin>\nPrefetch (next page resources):\n<link rel=\"prefetch\" href=\"/next-page.js\" as=\"script\">\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/SSR-Hydration-Data-Analysis": {
+    "output": "🚀 SSR Framework Hydration Analysis\n📭 No SSR framework hydration data detected.\nThis page may be:\n• A static HTML page\n• A client-side rendered SPA\n• Using a framework not yet supported by this snippet\nFound 0 other inline scripts (0 B)\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Script-Loading": {
+    "output": "📜 Script Loading Analysis\nTotal external scripts: 0\nTotal inline scripts: 0\nTotal size: -\nBy loading\n🔴 Blocking: 0 (-)\n⚡ Async: 0\n📋 Defer: 0\n📦 Module: 0\n📝 Best Practices\nFor most scripts (need DOM, run in order):\n<script src=\"app.js\" defer></script>\nFor independent scripts (analytics, ads):\n<script src=\"analytics.js\" async></script>\nFor ES\n<script type=\"module\" src=\"app.mjs\"></script>\nFor critical inline\n<script>/* Only essential initialization */</script>\nconsole.groupEnd\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/Service-Worker-Analysis": {
+    "output": "⚠️ Service Workers not supported in this browser",
+    "error": null
+  },
+  "Loading/TTFB-Resources": {
+    "output": "(no output)",
+    "error": null
+  },
+  "Loading/TTFB-Sub-Parts": {
+    "output": "⏱️\n────────────────────────────────────────────────────────────\n📊 Total TTFB                   0.00 ms\nconsole.groupEnd",
+    "error": null
+  },
+  "Loading/TTFB": {
+    "output": "(no output)",
+    "error": null
+  },
+  "Loading/Validate-Preload-Async-Defer-Scripts": {
+    "output": "✅ No script preloads found (rel=\"preload\" as=\"script\").\nℹ️ This is fine - only preload scripts if they're critical and blocking.",
+    "error": null
+  },
+  "Media/Image-Element-Audit": {
+    "output": "No <img> elements found on this page.",
+    "error": null
+  },
+  "Media/SVG-Embedded-Bitmap-Analysis": {
+    "output": "No SVG resources found on this page.",
+    "error": null
+  },
+  "Media/Video-Element-Audit": {
+    "output": "No <video> elements found on this page.",
+    "error": null
+  },
+  "Resources/Network-Bandwidth-Connection-Quality": {
+    "output": "📡 Network\nConnection\n{Connection Type: unknown, Effective Type: 4g, Downlink (Mbps): 10, RTT (ms): 0, Save-Data: Disabled}\n👂 Listening for connection changes... (navigate to trigger)\nconsole.groupEnd",
+    "error": null
+  }
+}


### PR DESCRIPTION
Closes #75

## What this PR does
Implements automatic console output capture at build time, 
as discussed in #75.

## How it works
1. `scripts/capture-outputs.js` — runs each snippet in a 
   headless Playwright browser and saves console output to 
   `snippets/outputs.json`
2. `scripts/inject-outputs.js` — reads the JSON and injects 
   the `output` prop into each `<Snippet>` in the MDX pages
3. `components/Snippet.jsx` — now renders an "Expected Output" 
   section below the code block when the prop is present
4. Both scripts are wired into `prebuild` to run automatically

## Example
Before: no output shown
After: shows expected console output below each snippet