### PR TITLE
feat: add timeout to snippet evaluation

### DIFF
--- a/cli/src/bin.js
+++ b/cli/src/bin.js
@@ -67,6 +67,7 @@ Options:
   --markdown            Output GitHub-renderable markdown (for PR comments)
   --viewport <preset>   Viewport preset: mobile (default), tablet, desktop
   --wait <ms>           Post-load wait before evaluating (default: 3000)
+  --evaluate-timeout <ms> Post-load evaluation timeout (default: 10000)
   --budget-lcp <ms>     Exit 1 if LCP exceeds this value
   --budget-cls <score>  Exit 1 if CLS exceeds this value
   --interact-script <path>  JSON file with interactions to run before evaluation
@@ -127,6 +128,7 @@ async function main() {
         json: { type: "boolean" },
         markdown: { type: "boolean" },
         wait: { type: "string" },
+        "evaluate-timeout": { type: "string" },
         "budget-lcp": { type: "string" },
         "budget-cls": { type: "string" },
         viewport: { type: "string" },
@@ -155,6 +157,7 @@ async function main() {
   }
 
   const waitMs = values.wait ? Number(values.wait) : 3000;
+  const evaluateTimeout = values["evaluate-timeout"] ? Number(values["evaluate-timeout"]) : 10000;
   const viewportName = values.viewport ?? "mobile";
   const viewport = VIEWPORT_PRESETS[viewportName];
   if (!viewport) {
@@ -166,12 +169,12 @@ async function main() {
   let payload;
   if (values.snippet) {
     const items = buildSnippetItem(values);
-    payload = await runSnippets({ url, items, waitMs, headless: !values.headed, viewport, interactScript });
+    payload = await runSnippets({ url, items, waitMs, evaluateTimeout, headless: !values.headed, viewport, interactScript });
   } else {
     const workflowName = values.workflow ?? "core-web-vitals";
     const workflow = WORKFLOWS[workflowName];
     if (!workflow) fail(`Unknown workflow: ${workflowName}`);
-    payload = await runMeasurement({ url, workflow, rules: RULES, waitMs, headless: !values.headed, viewport, interactScript });
+    payload = await runMeasurement({ url, workflow, rules: RULES, waitMs, evaluateTimeout, headless: !values.headed, viewport, interactScript });
   }
 
   let output;

--- a/cli/src/runner.js
+++ b/cli/src/runner.js
@@ -9,6 +9,7 @@ export const VIEWPORT_PRESETS = {
 };
 
 const DEFAULT_NAV_TIMEOUT = 30000;
+const DEFAULT_EVALUATE_TIMEOUT = 10000;
 
 // Snippets are IIFEs. Playwright evaluates a string as an expression, so we
 // trim trailing semicolons to keep the IIFE call as a single expression and
@@ -17,11 +18,16 @@ function toExpression(source) {
   return source.trim().replace(/;\s*$/, "");
 }
 
-async function evaluateItems(page, items) {
+async function evaluateItems(page, items, timeout = DEFAULT_EVALUATE_TIMEOUT) {
   const results = [];
   for (const item of items) {
     try {
-      const result = await page.evaluate(toExpression(item.source));
+      const result = await Promise.race([
+        page.evaluate(toExpression(item.source)),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("Snippet evaluation timed out")), timeout)
+        ),
+      ]);
       if (result && typeof result === "object") {
         results.push({ id: item.id, ...result });
       } else {
@@ -45,6 +51,7 @@ export async function runSnippets({
   headless = true,
   viewport = VIEWPORT_PRESETS.mobile,
   navTimeout = DEFAULT_NAV_TIMEOUT,
+  evaluateTimeout = DEFAULT_EVALUATE_TIMEOUT,
   interactScript,
 }) {
   const browser = await chromium.launch({ headless });
@@ -58,7 +65,7 @@ export async function runSnippets({
     if (waitMs > 0) await page.waitForTimeout(waitMs);
     const navMs = Date.now() - navStart;
     if (interactScript) await runInteractions(page, interactScript);
-    const results = await evaluateItems(page, items);
+    const results = await evaluateItems(page, items, evaluateTimeout);
     return { url, navMs, results, pageErrors };
   } finally {
     await browser.close();
@@ -73,6 +80,7 @@ export async function runMeasurement({
   headless = true,
   viewport = VIEWPORT_PRESETS.mobile,
   navTimeout = DEFAULT_NAV_TIMEOUT,
+  evaluateTimeout = DEFAULT_EVALUATE_TIMEOUT,
   interactScript,
 }) {
   const browser = await chromium.launch({ headless });
@@ -93,7 +101,7 @@ export async function runMeasurement({
       path: step.path,
       source: loadSnippet(step.path),
     }));
-    const initialResults = await evaluateItems(page, items);
+    const initialResults = await evaluateItems(page, items, evaluateTimeout);
 
     const followUps = [];
     for (const result of initialResults) {
@@ -109,7 +117,7 @@ export async function runMeasurement({
         path: f.path,
         source: loadSnippet(f.path),
       }));
-      const raw = await evaluateItems(page, followItems);
+      const raw = await evaluateItems(page, followItems, evaluateTimeout);
       followUpResults = raw.map((r) => {
         const f = followUps.find((x) => x.id === r.id);
         return f ? { ...r, reason: f.reason } : r;

--- a/cli/tests/e2e/timeout.test.js
+++ b/cli/tests/e2e/timeout.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createServer } from "node:http";
+import { runSnippets } from "../../src/runner.js";
+
+let server;
+let baseUrl;
+
+beforeAll(
+  () =>
+    new Promise((resolve) => {
+      server = createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end("<html><body></body></html>");
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address();
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    }),
+  10000
+);
+
+afterAll(
+  () =>
+    new Promise((resolve) => {
+      server.close(resolve);
+    })
+);
+
+describe("runSnippets — timeout", () => {
+  it("fails when a snippet hangs", async () => {
+    const items = [{ id: "hang", path: "test-hang", source: "(() => { while(true) {} })()" }];
+    const { results } = await runSnippets({
+      url: baseUrl,
+      items,
+      waitMs: 500,
+      evaluateTimeout: 1000,
+    });
+
+    expect(results[0].status).toBe("error");
+    expect(results[0].error).toContain("Snippet evaluation timed out");
+  });
+});


### PR DESCRIPTION
Added a timeout mechanism to snippet evaluation in `cli/src/runner.js` to prevent the CLI from hanging indefinitely when a snippet execution blocks the browser main thread. Also exposed this as a configurable option (`--evaluate-timeout`) in `cli/src/bin.js` and added an E2E test in `cli/tests/e2e/timeout.test.js` to verify the timeout behavior. Closes #1.