### PR TITLE
ci: guard against generated skills/dist drift

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,2 +1,4 @@
 #!/bin/sh
+set -e
 npm run check:consistency
+npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check consistency
         run: npm run check:consistency
 
+      - name: Check generated skills are up to date
+        run: npm run generate-skills:check
+
       - name: Run unit tests
         run: npm run test:unit --prefix cli
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prebuild": "rm -rf .next && node scripts/generate-llms.js",
     "check:consistency": "node scripts/check-consistency.js",
     "generate-skills": "node scripts/generate-skills.js",
-    "generate-skills:check": "node scripts/generate-skills.js && git diff --exit-code -- skills dist",
+    "generate-skills:check": "node scripts/generate-skills.js && git diff --exit-code -- skills dist .claude/skills",
     "install-skills": "node scripts/install-skills.js",
     "install-global": "node scripts/install-global.js",
     "install-from-release": "node scripts/install-from-release.js",


### PR DESCRIPTION
## What

Adds a CI guard so generated artifacts can no longer drift from their source.

- Runs `generate-skills:check` in the CI pipeline. A snippet or page change that does not regenerate `skills/`, `dist/`, and `.claude/skills/` now fails the build instead of publishing stale artifacts.
- Extends `generate-skills:check` to also diff `.claude/skills/`, the local-install mirror the generator writes but the check previously ignored.
- Hardens the pre-commit hook: runs `lint` alongside `check:consistency`, and adds `set -e` so a failing check actually blocks the commit.

## Why

`generate-skills:check` existed but was not wired into CI, and 169 generated files under `dist/` plus the `.claude/skills/` mirror could silently go out of sync with `snippets/` + `pages/`.

## Verification

- `generate-skills:check` exits 0 on a clean tree.
- Modifying a snippet source without regenerating makes it exit 1 (drift caught).
- `lint`, `check:consistency`, and the full pre-commit hook pass locally.