### PR TITLE
feat(demos): standardize the Demo embed contract on demoHeight

### DIFF
--- a/components/Demo.jsx
+++ b/components/Demo.jsx
@@ -1,18 +1,25 @@
 import { useEffect, useRef, useState } from "react";
 
+// Extra pixels added to the height the demo reports, so the iframe has a little
+// breathing room and never shows an inner scrollbar from sub-pixel rounding.
+const HEIGHT_PADDING = 24;
+
 /**
  * Embeds a self-contained interactive demo (a static HTML file under
  * `public/demos/`) inside an iframe. The demo reports its own content height
- * via `postMessage({ [heightKey]: number })`, so the iframe grows to fit
- * without an inner scrollbar. Theme (light/dark) syncs automatically: the demo
- * reads `localStorage.theme`, which Nextra also writes, and both share the same
- * origin.
+ * via `postMessage({ demoHeight: number })`, so the iframe grows to fit without
+ * an inner scrollbar. Theme (light/dark) syncs automatically: the demo reads
+ * `localStorage.theme`, which Nextra also writes, and both share the same
+ * origin. See `public/demos/README.md` for the full authoring contract.
+ *
+ * `heightKey` defaults to `"demoHeight"`; the handler also accepts a custom key
+ * as an escape hatch, but new demos should post `demoHeight`.
  */
 export function Demo({
   src,
   title,
   caption,
-  heightKey = "rafDemoHeight",
+  heightKey = "demoHeight",
   minHeight = 400,
 }) {
   const iframeRef = useRef(null);
@@ -21,9 +28,9 @@ export function Demo({
   useEffect(() => {
     function handleMessage(event) {
       if (event.source !== iframeRef.current?.contentWindow) return;
-      const value = event.data?.[heightKey];
+      const value = event.data?.[heightKey] ?? event.data?.demoHeight;
       if (typeof value === "number") {
-        setHeight(value + 24);
+        setHeight(value + HEIGHT_PADDING);
       }
     }
     window.addEventListener("message", handleMessage);
@@ -45,11 +52,17 @@ export function Demo({
           display: "block",
         }}
       />
-      {caption ? (
-        <figcaption className="nx-mt-2 nx-text-sm nx-text-gray-500 dark:nx-text-gray-400">
-          {caption}
-        </figcaption>
-      ) : null}
+      <figcaption className="nx-mt-2 nx-text-sm nx-text-gray-500 dark:nx-text-gray-400">
+        {caption ? <span>{caption} </span> : null}
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="nx-text-primary-600 nx-underline decoration-from-font"
+        >
+          Open demo in a new tab ↗
+        </a>
+      </figcaption>
     </figure>
   );
 }

--- a/public/demos/README.md
+++ b/public/demos/README.md
@@ -1,0 +1,117 @@
+# Interactive demos
+
+Self-contained HTML files embedded in the docs through the `<Demo />` component
+(`components/Demo.jsx`). Each file is a single page with no external dependencies:
+all CSS and JS are inline, so it works offline and inside a sandboxed iframe.
+
+A demo is worth building only for a **temporal or stateful** phenomenon, something
+the reader benefits from watching move (the parser pausing on a script, request
+waterfalls, metric sub-parts accumulating). Static mechanism diagrams and decision
+trees stay as mermaid in the MDX page.
+
+## The contract
+
+A demo must satisfy three things for the embed to behave.
+
+### 1. Report its height
+
+The iframe has no scrollbar of its own; it grows to fit its content. The demo
+measures its body and posts the height to the parent. The component listens for
+`demoHeight` and sizes the iframe to it (plus a small padding).
+
+```js
+function notifyHeight() {
+  window.parent.postMessage({ demoHeight: document.body.offsetHeight }, "*");
+}
+new ResizeObserver(notifyHeight).observe(document.body);
+```
+
+Post `demoHeight`. (A custom key can be passed to the component via the
+`heightKey` prop, but there is no reason to; standardize on `demoHeight`.)
+
+### 2. Sync the theme
+
+The demo shares the same origin as the docs, so it reads the theme Nextra writes
+to `localStorage.theme` and reacts to changes through the `storage` event. Style
+both themes: dark by default under `:root`, light under `[data-theme="light"]`.
+
+```js
+function applyTheme(t) {
+  document.documentElement.setAttribute("data-theme", t || "dark");
+}
+(function initTheme() {
+  const stored = localStorage.getItem("theme");
+  if (stored) return applyTheme(stored);
+  applyTheme(matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+})();
+addEventListener("storage", (e) => {
+  if (e.key === "theme") applyTheme(e.newValue);
+});
+matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+  if (!localStorage.getItem("theme")) applyTheme(e.matches ? "dark" : "light");
+});
+```
+
+### 3. Be self-contained
+
+No external scripts, styles, fonts, or network requests. Inline everything. The
+file must render identically whether opened directly (the "Open demo in a new
+tab" fallback link) or embedded.
+
+## Minimal template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Demo title</title>
+<style>
+  :root { --bg: #0d1117; --text: #e6edf3; /* dark palette */ }
+  [data-theme="light"] { --bg: #ffffff; --text: #1f2328; /* light palette */ }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { background: var(--bg); color: var(--text); padding: 16px;
+         font: 13px/1.4 -apple-system, system-ui, sans-serif; }
+</style>
+</head>
+<body>
+  <!-- interactive content here -->
+
+<script>
+  // ...demo logic...
+
+  // Theme
+  function applyTheme(t) { document.documentElement.setAttribute("data-theme", t || "dark"); }
+  (function initTheme() {
+    const stored = localStorage.getItem("theme");
+    if (stored) return applyTheme(stored);
+    applyTheme(matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  })();
+  addEventListener("storage", (e) => { if (e.key === "theme") applyTheme(e.newValue); });
+  matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+    if (!localStorage.getItem("theme")) applyTheme(e.matches ? "dark" : "light");
+  });
+
+  // Height
+  function notifyHeight() { window.parent.postMessage({ demoHeight: document.body.offsetHeight }, "*"); }
+  new ResizeObserver(notifyHeight).observe(document.body);
+</script>
+</body>
+</html>
+```
+
+## Embedding in a page
+
+```mdx
+import { Demo } from "../../components/Demo";
+
+<Demo
+  src="/demos/your-demo.html"
+  title="Accessible description of what the demo shows"
+  caption="One line telling the reader what to do (use the buttons, switch scenarios...)."
+/>
+```
+
+Keep the mermaid diagram that documents the internal mechanism or decision tree;
+the demo complements it, it does not replace mechanism documentation.

--- a/public/demos/network-waterfall.html
+++ b/public/demos/network-waterfall.html
@@ -573,7 +573,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e =
 
 // ─── Height notification ──────────────────────────────────────────────────────
 function notifyHeight() {
-  window.parent.postMessage({ netWaterfallHeight: document.body.offsetHeight }, '*');
+  window.parent.postMessage({ demoHeight: document.body.offsetHeight }, '*');
 }
 new ResizeObserver(notifyHeight).observe(document.body);
 </script>

--- a/public/demos/raf-pipeline.html
+++ b/public/demos/raf-pipeline.html
@@ -535,7 +535,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e =
 // ─── Height notification ───────────────────────────────────────────────────────
 function notifyHeight() {
   const h = document.body.offsetHeight;
-  window.parent.postMessage({ rafDemoHeight: h }, '*');
+  window.parent.postMessage({ demoHeight: h }, '*');
 }
 new ResizeObserver(notifyHeight).observe(document.body);
 </script>

--- a/public/demos/yield-pipeline.html
+++ b/public/demos/yield-pipeline.html
@@ -529,7 +529,7 @@ window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e =
 // ─── Height notification ──────────────────────────────────────────────────────
 function notifyHeight() {
   const h = document.body.offsetHeight;
-  window.parent.postMessage({ yieldDemoHeight: h }, '*');
+  window.parent.postMessage({ demoHeight: h }, '*');
 }
 new ResizeObserver(notifyHeight).observe(document.body);
 </script>


### PR DESCRIPTION
## What

Standardizes the interactive-demo embed contract so new demos are trivial to author and existing ones size correctly.

- Defaults the `<Demo>` component's `heightKey` to `demoHeight` (falls back to `demoHeight` regardless of the prop).
- Migrates the three existing demos (raf-pipeline, yield-pipeline, network-waterfall) to post `demoHeight`.
- Names the height-padding constant and adds an always-visible "Open demo in a new tab" fallback link.
- Documents the authoring contract (height reporting, theme sync, self-contained) with a copyable template in `public/demos/README.md`.

## Why

The three demos each posted a unique height key (`rafDemoHeight`, `yieldDemoHeight`, `netWaterfallHeight`) but no page passed `heightKey`, so only `raf-pipeline` matched the old default. `yield-pipeline` and `network-waterfall` were stuck at the 400px minimum, their real height never applied.

## Verification (runtime, `next dev`)

| Demo | Page | iframe height | body + 24 |
|------|------|---------------|-----------|
| yield-pipeline | LongTask | 439 | ✅ (was stuck at 400) |
| network-waterfall | Resource-Hints | 627 | ✅ (was stuck at 400) |
| raf-pipeline | FSL | 442 | ✅ |

Also verified: dynamic auto-height via ResizeObserver (added 300px to the demo body → iframe grew by 314, reverted exactly on removal), light↔dark theme sync, and the fallback link renders with the correct href.